### PR TITLE
Feat/guide open config buttons

### DIFF
--- a/docs/fix-cspell-dictionary-pollution.md
+++ b/docs/fix-cspell-dictionary-pollution.md
@@ -1,0 +1,177 @@
+# Fix: cspell-roles.txt Dictionary Pollution from TXT Role Files
+
+## Problem
+
+The `.vscode/cspell-roles.txt` dictionary file contained large amounts of non-name content — full sentences, section headers, property fields, and narrative paragraphs — instead of just character names and terms.
+
+### Example of polluted output
+
+Before the fix, `cspell-roles.txt` contained entries like:
+
+```
+（本档案已更新至第三十五章·烬灭临渊）
+一、核心主角
+称号：烬灭真君
+外貌：黑发，眼神深邃锐利，面容俊朗但常带一丝疏离和淡漠。穿着简约，偏好深色系衣物
+告别青龙秘境，与凤凰、陈汐梅返回穗城。
+11
+1岁
+Ch
+```
+
+Only a fraction of the 657 entries were actual character names (like `李修缘`, `陈汐梅`).
+
+## Root Cause
+
+The issue involved two interacting problems:
+
+### 1. External folder scanning matched structured character data files
+
+`scanExternalRoleFoldersWithReport()` scans the entire workspace for files with extensions `.txt` `.md` `.json5` `.csv` and checks their filenames against marker keywords. When a user maintained structured character profiles in `小说设定/角色/` with filenames containing "人物" (a default marker keyword), the directory was added to the role scanning queue.
+
+### 2. `loadTXTRoleFile` treated every line as a role name
+
+[src/utils/utils.ts:1232](src/utils/utils.ts) — The original `loadTXTRoleFile()` treated **every non-empty, non-comment line** in a `.txt` file as a role name:
+
+```
+（本档案已更新至第三十五章·烬灭临渊）  → role.name = 整行
+一、核心主角                          → role.name = 整行
+李修缘                                → role.name = "李修缘"  ← 唯一正确的
+称号：烬灭真君                        → role.name = 整行
+外貌：黑发，眼神深邃锐利...             → role.name = 整行
+```
+
+Structured character data files contain many non-name lines (metadata, section headers, property fields, narratives), but `loadTXTRoleFile` had no mechanism to distinguish names from other content.
+
+### Why this matters
+
+All role names (including bogus ones) flowed into `generateCSpellDictionary()`, which wrote them verbatim into `cspell-roles.txt`. This effectively disabled cspell's usefulness, as it would no longer flag misspelled words that happened to match any line in the character data files.
+
+## Fix Summary
+
+Two-layer defense added across two files:
+
+### L1 — Source Filter in `loadTXTRoleFile`
+
+**File**: [src/utils/utils.ts](src/utils/utils.ts#L1232)
+
+**New function**: `isLikelyNonNameLine(line: string): boolean`
+
+Filters lines before they become role objects:
+
+| Rule | Rationale | Example matched |
+|------|-----------|----------------|
+| Length > 50 chars | Narrative text, not names/vocab | `告别青龙秘境，与凤凰、陈汐梅返回穗城。` |
+| Starts with bracket `（([【[` | Metadata / section markers | `（本档案已更新至...）` `【九霄焚世真诀】` |
+| Contains colon `：:` | Property fields | `称号：烬灭真君` `核心能力：` |
+| Numbered header pattern | Section titles | `一、核心主角` `1. xxx` |
+| Punctuation + length > 15 | Descriptive sentences | `外貌：黑发，眼神深邃...` |
+| Chinese paired parentheses | Annotations on names | `"力"（新增）` `乔鸿煊（大哥）` |
+
+**Integration point**: Called immediately after comment stripping, before `const role: Role = {...}`:
+
+```
+for (const raw of rawLines) {
+    let line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('#') || line.startsWith('//')) continue;
+    // ... inline comment stripping ...
+    if (isLikelyNonNameLine(line)) continue;  // ← NEW
+    const role: Role = { name: line, ... };
+}
+```
+
+### L2 — Dictionary Filter in `generateCSpellDictionary`
+
+**File**: [src/utils/generateCSpellDictionary.ts](src/utils/generateCSpellDictionary.ts#L9)
+
+**New function**: `isLikelyNonNameWord(word: string): boolean`
+
+Format-agnostic final filter applied to the word set before writing:
+
+| Rule | Rationale |
+|------|-----------|
+| Length > 25 chars | Not a name/term |
+| Contains Chinese punctuation `：。，！？；、""''（）【】《》…—` | Sentence fragments |
+| Contains English punctuation `,.;:!?"()` | Non-name content |
+| Contains whitespace | Multi-word fragments |
+
+**Integration point**: Between word collection and sort/write:
+
+```
+const wordSet = new Set<string>();
+// ... collect all role names and aliases ...
+const filtered = Array.from(wordSet).filter(word => !isLikelyNonNameWord(word)); // ← NEW
+const sorted = filtered.sort(...);
+const newContent = sorted.join('\n');
+```
+
+## Before vs After
+
+### Before (original logic)
+
+```
+loadTXTRoleFile:
+  for each line in .txt file:
+    if (!empty && !comment):
+      create Role({ name: line })   ← EVERY line becomes a role
+
+generateCSpellDictionary:
+  for each role:
+    wordSet.add(role.name)          ← ALL names go directly into dictionary
+    wordSet.add(tokenized parts)
+  write wordSet to cspell-roles.txt
+```
+
+### After (with fix)
+
+```
+loadTXTRoleFile:
+  for each line in .txt file:
+    if (!empty && !comment):
+      if isLikelyNonNameLine(line):  ← L1: heuristic filter
+        continue                      ← skip section headers, properties, narratives
+      create Role({ name: line })    ← only name-like lines become roles
+
+generateCSpellDictionary:
+  for each role:
+    wordSet.add(role.name)
+    wordSet.add(tokenized parts)
+  filtered = wordSet.filter(!isLikelyNonNameWord)  ← L2: format-agnostic final filter
+  write filtered to cspell-roles.txt
+```
+
+## What This Prevents
+
+| Scenario | How it's handled |
+|----------|-----------------|
+| User writes structured character profiles in any `.txt` file | L1 filters out non-name lines by heuristics |
+| User changes their character data format in the future | L2 catches anything with punctuation, whitespace, or excessive length regardless of format |
+| JSON5/Markdown role files with description fields | L2 ensures only `role.name` entries (short, no punctuation) enter the dictionary |
+| Tokenized fragments that are too long or contain artifacts | L2 filters them out |
+
+## Verification
+
+Tested against real-world character data file (`截止第三十四章登场人物信息.txt`, 301 non-empty lines):
+
+| Stage | Entries | Notes |
+|-------|---------|-------|
+| Original (unfiltered) | 657 | role names + tokenized fragments |
+| With L1 only | ~35 roles created | Section headers, properties, narratives all skipped |
+| With L2 only | 111 dict entries | 83% reduction from original 657 |
+| With L1 + L2 | Clean output | Only genuine character names and terms |
+
+## Risk Assessment
+
+- **Low risk**: L1 only affects `.txt` role files. JSON5, Markdown, and CSV role files use separate loaders and are unaffected.
+- **Conservative L1**: The `isLikelyNonNameLine` rules use safe thresholds (50 chars for length, explicit punctuation patterns) that are extremely unlikely to match legitimate Chinese/Japanese character names.
+- **L2 is format-agnostic**: Even if a future file format produces unexpected output, L2's punctuation and length checks provide a safety net.
+- **False negative risk**: A legitimate role name containing a colon (e.g., "A:B") would be filtered by L1. Such names are virtually non-existent in Chinese novel writing. If needed, these can be added via JSON5/Markdown role files which bypass the TXT line filter.
+- **Non-breaking**: The role objects themselves are preserved in `roles[]` even if filtered from the cspell dictionary. Role highlighting, completion, and other features continue to work.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/utils/utils.ts` | Added `isLikelyNonNameLine()` helper function. Added filter call in `loadTXTRoleFile()` |
+| `src/utils/generateCSpellDictionary.ts` | Added `isLikelyNonNameWord()` helper function. Added filter step between collection and sort/write |

--- a/docs/guide-open-config-buttons.md
+++ b/docs/guide-open-config-buttons.md
@@ -1,0 +1,61 @@
+# Feature: "Open Config" Quick Buttons in Guide Page
+
+## Summary
+
+Added an "Open Config" button to each of the four feature cards in the "Roles & Resources" section of the ANH Guide page. One click detects and opens the corresponding configuration file in the project.
+
+## Problem
+
+Previously, the guide cards only had a "View Docs" button. After reading the docs, users had to manually navigate to the `novel-helper/` directory and find the right config file. New users often didn't know where the files were or what they should be named.
+
+## Solution
+
+Each feature card now has an "打开配置" (Open Config) button:
+
+| Files found | Behavior |
+|-------------|----------|
+| 0 | Prompt to choose format (JSON5 / MD) → auto-create template with default filename → open |
+| 1 | Open directly |
+| 2+ | QuickPick list for user to choose |
+
+### Four Commands
+
+| Card | Command ID | Default File | Search Keywords |
+|------|-----------|-------------|-----------------|
+| 角色管理 (Roles) | `andrea.openRoleConfig` | `character-gallery.*` | `character-gallery`, `character`, `role`, `roles` |
+| 敏感词检测 (Sensitive Words) | `andrea.openSensitiveConfig` | `sensitive-words.*` | `sensitive-words`, `sensitive`, `敏感词` |
+| 词汇表 (Vocabulary) | `andrea.openVocabConfig` | `vocabulary.*` | `vocabulary`, `vocab`, `词汇`, `术语` |
+| 正则着色 (Regex Coloring) | `andrea.openRegexConfig` | `regex-patterns.*` | `regex-patterns`, `regex`, `正则` |
+
+### File Opening
+
+All types use the default text editor (`vscode.openWith ... default`) to avoid the Role JSON5 custom editor incorrectly rendering sensitive-word, vocabulary, and regex-pattern `.json5` files as character forms.
+
+## UI
+
+```
+┌─────────────────────────────────────────┐
+│  🧑  Role Management                     │
+│  Manage characters via role card editor.  │
+│  [View Docs] [Open Config]                │
+└─────────────────────────────────────────┘
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/guide/guidePage.ts` | Added `CONFIG_TYPES` mapping, `findConfigFiles()` scanner, `openOrCreateConfig()` open/create logic, `openFileForType()` helper, 4 command registrations |
+| `media/guide.html` | Added "打开配置" button next to "查看文档" in each of the 4 cards (via `data-cmd` attributes) |
+
+### Reuses Existing Infrastructure
+
+- File scanning: lightweight keyword + extension matching
+- Template creation: simplified inline templates matching `templateGenerators.ts` style
+- Button clicks: reused `guide.js` existing `[data-cmd]` event delegation
+
+## Compatibility
+
+- Non-breaking: only adds UI buttons and commands
+- Buttons are in the Guide page WebView only (not sidebar or context menus)
+- Guides user to create a file when none exists; never errors out

--- a/docs/txt-role-migration.md
+++ b/docs/txt-role-migration.md
@@ -4,8 +4,6 @@
 
 When users already maintain character data as structured `.txt` files outside the `novel-helper/` directory (e.g., `小说设定/角色/截止第三十四章登场人物信息.txt`), ANH now automatically detects them and offers one-click conversion to standard JSON5 or Markdown format.
 
-This bridges the gap between "free-form TXT character notes" and "ANH's structured role system" — users can keep their existing workflow and migrate when ready.
-
 ## Problem
 
 - Many authors write character profiles as free-form TXT files before adopting ANH
@@ -15,19 +13,29 @@ This bridges the gap between "free-form TXT character notes" and "ANH's structur
 
 ## Solution
 
-### Three-layer detection
+### Detection engine (configurable)
 
-| Layer | Method | Purpose |
-|-------|--------|---------|
-| **L1 — Filename** | Keywords: 角色, 人物, character, 登场, 设定, etc. | Quick filter — skip novel chapters and unrelated files |
-| **L2 — Directory** | Boost confidence for files under `小说设定/角色/` etc. | High-confidence directories lower the content scoring threshold (30 vs 50) |
-| **L3 — Content scoring** | Property-line density, short-name-line density, section header count, block structure, long-paragraph penalty | Distinguish character profiles (score 65-77) from novel chapters (score 0) and skill lists (score 0-50, filtered at L1) |
+Three-layer detection with all parameters exposed via VS Code settings:
 
-Each candidate gets a 0-100 score; candidates ≥50 (or ≥30 in high-confidence dirs) are surfaced to the user.
+| Layer | Method | Configurable via |
+|-------|--------|-----------------|
+| **L1 — Filename** | Keywords matched against filename | `txtMigration.detectionKeywords` |
+| **L2 — Directory** | Boost confidence for files under known character dirs | `txtMigration.highConfidenceDirs` |
+| **L3 — Content scoring** | Property-line density, short-name-line density, section header count, block structure | `txtMigration.scoreThreshold` / `txtMigration.highConfidenceScoreThreshold` |
+
+All settings live under `AndreaNovelHelper.txtMigration.*` with sensible defaults. Users can customize via VS Code Settings UI, `settings.json`, or project JSON5 config.
+
+### Feature toggle
+
+`AndreaNovelHelper.txtMigration.enabled` (default `true`). When disabled:
+- Status bar indicator hidden
+- Auto-popup suppressed
+- Sidebar "转换 TXT 角色档案" node hidden
+- Manual command still available
 
 ### Structured TXT parser
 
-Parses common Chinese character-profile formats:
+Parses common Chinese character-profile formats with 30+ field keyword mappings:
 
 ```
 （本档案已更新至第三十五章）     → skipped (meta)
@@ -43,27 +51,29 @@ Parses common Chinese character-profile formats:
 Features:
 - Property extraction: 30+ Chinese field keywords (`称号`→`title`, `外貌`→`appearance`, etc.)
 - Quote/parenthesis stripping: `"力"（新增）` → `力`
+- `&` connector handling: `李佳 & 天一` → `李佳` + `天一` (split)
+- `/` separator preserved for manual review (`蓝湛 / "镜"`)
 - Multi-line field aggregation
 - Section-aware grouping
-- `&` connector handling
+
+### Output
+
+- **Filename**: `<original_name>.json5` or `<original_name>.md` (e.g., `截止第三十四章登场人物信息.json5`)
+- **Location**: `novel-helper/` under the correct workspace root (multi-root safe)
+- **Format**: Proper JSON5 (via `JSON5.stringify`) handling arrays, numbers, and booleans correctly
+- **Safety**: Original `.txt` backed up as `.txt.bak`, overwrite prompt if target exists
 
 ### Migration workflow
 
 ```
-Project open → auto-detect → notification popup (if no JSON5 exists)
-  → click "开始转换" / status bar / command palette
-    → QuickPick: file list with scores and summaries
-      → select file → preview extracted roles and sections
-        → choose format (JSON5 recommended / Markdown)
-          → auto-backup TXT → write character-gallery.json5
+Project open → async detection (non-blocking, 100ms debounce)
+  → auto-popup (if no character-gallery.json5 exists and feature enabled)
+    → click "开始转换" / status bar / command palette / sidebar node
+      → QuickPick: file list with scores and summaries
+        → select file → preview extracted roles and sections
+          → choose format (JSON5 / Markdown)
+            → auto-backup TXT → write to novel-helper/
 ```
-
-Safety measures:
-1. Original `.txt` file backed up as `.txt.bak` before conversion
-2. Conversion preview shows extracted roles before writing
-3. If `character-gallery.json5` already exists, user is prompted before overwrite
-4. `/` separator in names (e.g., `蓝湛 / "镜"`) preserves ambiguity for manual review
-5. Auto-prompt only fires when no JSON5 exists yet
 
 ### UI entry points
 
@@ -71,25 +81,31 @@ Safety measures:
 |-------|---------------|
 | **Auto-popup** | On project open, if TXT candidates detected and no `character-gallery.json5` |
 | **Status bar** | `"N 个 TXT 角色档案"` — click to open file list |
-| **Command palette** | `andrea.detectTxtRoleFiles` ("检测 TXT 角色档案并迁移") |
-| **Common Features panel** | `+ 转换 TXT 角色档案` node in the role management sidebar |
+| **Command palette** | `Ctrl+Shift+P` → `andrea.detectTxtRoleFiles` / "检测 TXT 角色档案并迁移" |
+| **Sidebar** | "常用功能" → `+ 转换 TXT 角色档案` (conditional, uses cached async detection) |
+
+## VS Code Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `AndreaNovelHelper.txtMigration.enabled` | boolean | `true` | Master toggle for TXT migration |
+| `AndreaNovelHelper.txtMigration.detectionKeywords` | string[] | `["角色","人物","character","role"...]` | Filename keywords for L1 |
+| `AndreaNovelHelper.txtMigration.highConfidenceDirs` | string[] | `["角色","人物","characters","roles"]` | Directory names for L2 boost |
+| `AndreaNovelHelper.txtMigration.scoreThreshold` | number | `50` | Content score threshold (non-high-confidence dirs) |
+| `AndreaNovelHelper.txtMigration.highConfidenceScoreThreshold` | number | `30` | Content score threshold (high-confidence dirs) |
 
 ## Verification
 
 Tested against real-world character data (`截止第三十四章登场人物信息.txt`, 301 non-empty lines, ~45 characters):
 
-| Metric | Before | After |
-|--------|--------|-------|
-| Detection score | — | **77/100** (ROLE FILE) |
-| Characters extracted | — | **38** (out of ~39 identifiable, 97%) |
-| Novel chapter (第一章) | — | **0/100** (correctly excluded) |
-| Skill list (火系异能) | — | Filtered at L1 (no role keyword in filename) |
-| Missed: 1 | — | `蓝湛 / "镜"` (`/` reserved for manual review) |
-
-Detection accuracy:
-- Character profiles: correctly identified (score 65-77)
-- Novel chapters: correctly excluded (score 0, long-paragraph penalty)
-- Skill/ability lists: filtered at L1 filename check
+| Metric | Result |
+|--------|--------|
+| Detection score | **77/100** |
+| Characters extracted | **38** (~84%) |
+| Missed | 1 (`蓝湛 / "镜"` — `/` reserved for manual review) |
+| Novel chapter (第一章 云中惊魂.txt) | **0/100** (correctly excluded) |
+| Skill list (火系异能技能.txt) | Filtered at L1 (no role keyword in filename) |
+| JSON5 output validity | Valid, arrays/numbers/booleans handled correctly |
 
 ## Files Changed
 
@@ -97,9 +113,9 @@ Detection accuracy:
 
 | File | Purpose |
 |------|---------|
-| `src/utils/txtRoleDetector.ts` | Three-layer TXT file detection with content scoring |
-| `src/utils/txtRoleParser.ts` | Structured TXT → Role[] parser + JSON5/MD output |
-| `src/commands/txtMigrationCommands.ts` | Auto-popup, status bar, QuickPick UI, migration execution |
+| `src/utils/txtRoleDetector.ts` | Configurable three-layer TXT file detection with content scoring |
+| `src/utils/txtRoleParser.ts` | Structured TXT → Role[] parser + JSON5/MD output (uses JSON5.stringify) |
+| `src/commands/txtMigrationCommands.ts` | Auto-popup, status bar (subscription-safe), QuickPick UI, migration execution (multi-root safe) |
 | `docs/txt-role-migration.md` | This document |
 
 ### Modified files
@@ -107,14 +123,15 @@ Detection accuracy:
 | File | Change |
 |------|--------|
 | `src/activate.ts` | Added import and `registerTxtMigrationCommands(context)` call |
-| `package.json` | Added `andrea.detectTxtRoleFiles` and `andrea.migrateTxtRoleFile` commands |
-| `src/Provider/view/packageManagerView.ts` | Added `TxtMigrationNode` to "常用功能" panel (conditional on TXT candidates) |
-| `media/docs/role-management.html` | Added "TXT 角色档案迁移" section to role management docs |
+| `package.json` | Added 5 VS Code settings + 2 commands |
+| `src/Provider/view/packageManagerView.ts` | Added `TxtMigrationNode` with async cached detection (non-blocking TreeView) + feature toggle check |
+| `media/docs/role-management.html` | Added "TXT 角色档案迁移" section to user-facing docs |
 
 ## Compatibility
 
 - Non-breaking: does not modify existing role loading or parsing code paths
-- Optional: no popup if `character-gallery.json5` already exists
-- No dependency on TXT file format changes — users can keep their existing files
-- Works alongside existing JSON5/MD/CSV role formats
-- All existing security/backup patterns followed (`.bak` before write, user confirmation before destructive action)
+- Optional: feature toggle allows disabling everything
+- Multi-root safe: output goes to the correct workspace folder for each source file
+- Memory safe: statusBarItem properly disposed via context.subscriptions
+- UI non-blocking: detection uses debounced timer, not synchronous in getChildren()
+- All rules/configurations exposed via VS Code settings with defaults matching original behavior

--- a/docs/txt-role-migration.md
+++ b/docs/txt-role-migration.md
@@ -1,0 +1,120 @@
+# Feature: TXT 角色档案自动检测与迁移
+
+## Summary
+
+When users already maintain character data as structured `.txt` files outside the `novel-helper/` directory (e.g., `小说设定/角色/截止第三十四章登场人物信息.txt`), ANH now automatically detects them and offers one-click conversion to standard JSON5 or Markdown format.
+
+This bridges the gap between "free-form TXT character notes" and "ANH's structured role system" — users can keep their existing workflow and migrate when ready.
+
+## Problem
+
+- Many authors write character profiles as free-form TXT files before adopting ANH
+- These TXT files have recognizable structure (character names, property fields like `称号： xxx`, section headers like `一、核心主角`) but are not machine-readable by ANH
+- Without conversion, users can't benefit from role highlighting, completion, relationship graphs, or auto-generated cSpell dictionaries
+- Previously, users had to manually recreate every character in JSON5/Markdown — error-prone and time-consuming for files with 40+ characters
+
+## Solution
+
+### Three-layer detection
+
+| Layer | Method | Purpose |
+|-------|--------|---------|
+| **L1 — Filename** | Keywords: 角色, 人物, character, 登场, 设定, etc. | Quick filter — skip novel chapters and unrelated files |
+| **L2 — Directory** | Boost confidence for files under `小说设定/角色/` etc. | High-confidence directories lower the content scoring threshold (30 vs 50) |
+| **L3 — Content scoring** | Property-line density, short-name-line density, section header count, block structure, long-paragraph penalty | Distinguish character profiles (score 65-77) from novel chapters (score 0) and skill lists (score 0-50, filtered at L1) |
+
+Each candidate gets a 0-100 score; candidates ≥50 (or ≥30 in high-confidence dirs) are surfaced to the user.
+
+### Structured TXT parser
+
+Parses common Chinese character-profile formats:
+
+```
+（本档案已更新至第三十五章）     → skipped (meta)
+一、核心主角                    → section grouping
+李修缘                         → character name
+称号：烬灭真君                  → property (title)
+年龄：未知（外表约25岁）         → property (age)
+外貌：黑发，眼神深邃锐利...      → property (appearance)
+新增动态：                      → multi-line field (dynamics)
+告别青龙秘境，与凤凰返回穗城。   → field continuation
+```
+
+Features:
+- Property extraction: 30+ Chinese field keywords (`称号`→`title`, `外貌`→`appearance`, etc.)
+- Quote/parenthesis stripping: `"力"（新增）` → `力`
+- Multi-line field aggregation
+- Section-aware grouping
+- `&` connector handling
+
+### Migration workflow
+
+```
+Project open → auto-detect → notification popup (if no JSON5 exists)
+  → click "开始转换" / status bar / command palette
+    → QuickPick: file list with scores and summaries
+      → select file → preview extracted roles and sections
+        → choose format (JSON5 recommended / Markdown)
+          → auto-backup TXT → write character-gallery.json5
+```
+
+Safety measures:
+1. Original `.txt` file backed up as `.txt.bak` before conversion
+2. Conversion preview shows extracted roles before writing
+3. If `character-gallery.json5` already exists, user is prompted before overwrite
+4. `/` separator in names (e.g., `蓝湛 / "镜"`) preserves ambiguity for manual review
+5. Auto-prompt only fires when no JSON5 exists yet
+
+### UI entry points
+
+| Entry | How to access |
+|-------|---------------|
+| **Auto-popup** | On project open, if TXT candidates detected and no `character-gallery.json5` |
+| **Status bar** | `"N 个 TXT 角色档案"` — click to open file list |
+| **Command palette** | `andrea.detectTxtRoleFiles` ("检测 TXT 角色档案并迁移") |
+| **Common Features panel** | `+ 转换 TXT 角色档案` node in the role management sidebar |
+
+## Verification
+
+Tested against real-world character data (`截止第三十四章登场人物信息.txt`, 301 non-empty lines, ~45 characters):
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Detection score | — | **77/100** (ROLE FILE) |
+| Characters extracted | — | **38** (out of ~39 identifiable, 97%) |
+| Novel chapter (第一章) | — | **0/100** (correctly excluded) |
+| Skill list (火系异能) | — | Filtered at L1 (no role keyword in filename) |
+| Missed: 1 | — | `蓝湛 / "镜"` (`/` reserved for manual review) |
+
+Detection accuracy:
+- Character profiles: correctly identified (score 65-77)
+- Novel chapters: correctly excluded (score 0, long-paragraph penalty)
+- Skill/ability lists: filtered at L1 filename check
+
+## Files Changed
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `src/utils/txtRoleDetector.ts` | Three-layer TXT file detection with content scoring |
+| `src/utils/txtRoleParser.ts` | Structured TXT → Role[] parser + JSON5/MD output |
+| `src/commands/txtMigrationCommands.ts` | Auto-popup, status bar, QuickPick UI, migration execution |
+| `docs/txt-role-migration.md` | This document |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/activate.ts` | Added import and `registerTxtMigrationCommands(context)` call |
+| `package.json` | Added `andrea.detectTxtRoleFiles` and `andrea.migrateTxtRoleFile` commands |
+| `src/Provider/view/packageManagerView.ts` | Added `TxtMigrationNode` to "常用功能" panel (conditional on TXT candidates) |
+| `media/docs/role-management.html` | Added "TXT 角色档案迁移" section to role management docs |
+
+## Compatibility
+
+- Non-breaking: does not modify existing role loading or parsing code paths
+- Optional: no popup if `character-gallery.json5` already exists
+- No dependency on TXT file format changes — users can keep their existing files
+- Works alongside existing JSON5/MD/CSV role formats
+- All existing security/backup patterns followed (`.bak` before write, user confirmation before destructive action)

--- a/media/docs/role-management.html
+++ b/media/docs/role-management.html
@@ -234,6 +234,18 @@ Reimu
 </ul>
 <p>也可以通过命令面板执行 <code>AndreaNovelHelper.createCharacterGallery</code> 或 <code>AndreaNovelHelper.createRoleFile</code>。</p>
 
+<h4>TXT 角色档案迁移</h4>
+<p>如果你已经用 TXT 整理了角色档案（例如章节列表中的人设草稿），ANH 可以自动检测并一键转换为标准的 JSON5 或 Markdown 格式：</p>
+<ul>
+    <li>打开项目后，ANH 会自动扫描工作区中文件名包含"角色""人物""登场"等关键词的 <code>.txt</code> 文件</li>
+    <li>如果检测到 TXT 角色档案且项目中尚无 <code>character-gallery.json5</code>，右下角会弹窗提示转换</li>
+    <li>也可以在左侧"常用功能"面板中点击 <b>+ 转换 TXT 角色档案</b>，或通过命令面板 (<code>Ctrl+Shift+P</code>) 搜索 <code>andrea.detectTxtRoleFiles</code>（"检测 TXT 角色档案并迁移"）手动触发</li>
+    <li>选择文件后，ANH 会解析 TXT 中的角色名、属性字段（称号、年龄、外貌、性格等）、分组结构，并生成预览</li>
+    <li>确认后自动备份原 TXT 文件（<code>.txt.bak</code>），输出 JSON5 或 Markdown 到 <code>novel-helper/</code> 目录</li>
+    <li>支持命名约定：<code>截止第N章登场人物信息.txt</code>、<code>角色设定.txt</code>、<code>人物档案.txt</code> 等均可识别</li>
+</ul>
+<p>解析器能够自动处理中文冒号属性行（称号：xxx）、章节标题（一、二、三…）、括号注释（新增）（未正式登场）等常见格式。转换前可预览结果，转换后不会删除原始文件。</p>
+
 <h4>样式字段说明</h4>
 <p>角色外观有两种写法，新版推荐 <code>style</code> 对象，旧版独立字段保持兼容：</p>
 <pre><code>// 新版推荐

--- a/media/guide.html
+++ b/media/guide.html
@@ -397,6 +397,7 @@
                         <div class="card-desc">通过角色卡编辑器管理角色信息。支持 JSON5、CSV、Markdown 等格式。角色会在编辑器中自动高亮和补全。</div>
                         <div class="card-actions">
                             <button class="doc-toggle" data-doc-id="role-management">查看文档</button>
+                            <button data-cmd="andrea.openRoleConfig">打开配置</button>
                             <span class="hint">在包管理器中右键文件夹可新建角色库</span>
                         </div>
                     </div>
@@ -409,6 +410,7 @@
                         <div class="card-desc">定义敏感词库，编辑器会实时标记匹配的词汇。支持自定义严重级别、别名和修复建议。</div>
                         <div class="card-actions">
                             <button class="doc-toggle" data-doc-id="sensitive-words">查看文档</button>
+                            <button data-cmd="andrea.openSensitiveConfig">打开配置</button>
                             <span class="hint">在包管理器中右键文件夹可新建敏感词库</span>
                         </div>
                     </div>
@@ -421,6 +423,7 @@
                         <div class="card-desc">管理世界观术语和专业词汇。支持分类、别名、自动补全和高亮显示。</div>
                         <div class="card-actions">
                             <button class="doc-toggle" data-doc-id="vocabulary">查看文档</button>
+                            <button data-cmd="andrea.openVocabConfig">打开配置</button>
                             <span class="hint">在包管理器中右键文件夹可新建词汇表</span>
                         </div>
                     </div>
@@ -433,6 +436,7 @@
                         <div class="card-desc">用正则表达式定义自定义着色规则。可匹配对话、书名号、特殊标记等，用颜色直观区分文本类型。</div>
                         <div class="card-actions">
                             <button class="doc-toggle" data-doc-id="regex-coloring">查看文档</button>
+                            <button data-cmd="andrea.openRegexConfig">打开配置</button>
                             <span class="hint">在包管理器中右键文件夹可新建着色规则</span>
                         </div>
                     </div>

--- a/package.json
+++ b/package.json
@@ -928,6 +928,16 @@
         "category": "Andrea Novel Helper"
       },
       {
+        "command": "andrea.detectTxtRoleFiles",
+        "title": "检测 TXT 角色档案并迁移",
+        "category": "Andrea Novel Helper"
+      },
+      {
+        "command": "andrea.migrateTxtRoleFile",
+        "title": "迁移 TXT 角色档案",
+        "category": "Andrea Novel Helper"
+      },
+      {
         "command": "andrea.typo.scanDocument",
         "title": "扫描错别字（未扫描段落）",
         "category": "Andrea Novel Helper"

--- a/package.json
+++ b/package.json
@@ -1,4359 +1,4416 @@
 {
-  "name": "andrea-novel-helper",
-  "displayName": "Novel Helper 小说助手 (Andrea Novel Helper)",
-  "description": "功能较完备的小说写作辅助：角色/词汇/敏感词库定义与管理、引用追踪与角色引用热力图、异步高亮匹配、双重大纲与包管理、写作时间与字数统计、正则表达式与补全、文件追踪、时间线与角色关系等。ANH 已作为面向小说创作的 IDE 环境构建，提供从资源管理到编辑辅助的一体化工具。(A full-featured novel-writing assistant integrated into ANH — an IDE-like environment for novel authors: define and manage characters, vocabulary and sensitive-word libraries; track references and character usage (including heatmaps); async highlight matching; dual outlines and package management; timelines and relationship graphs; writing time and word-count statistics; regex patterns, completions and editor integrations; file tracking, WebDAV/AutoGit sync and other end-to-end writing tools.)",
-  "version": "0.5.4",
-  "engines": {
-    "vscode": "^1.100.0"
-  },
-  "homepage": "https://anh.sirrus.cc",
-  "publisher": "andreafrederica",
-  "license": "MPL-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/AndreaFrederica/andrea-novel-helper.git"
-  },
-  "icon": "images/icon.png",
-  "categories": [
-    "Other"
-  ],
-  "keywords": [
-    "andrea",
-    "novel",
-    "helper",
-    "writing",
-    "assistant",
-    "小说",
-    "小説",
-    "作家",
-    "写作",
-    "助手",
-    "角色",
-    "大纲",
-    "时间线",
-    "关系图",
-    "词汇",
-    "敏感词",
-    "统计",
-    "同步",
-    "WebDAV",
-    "AutoGit",
-    "脚本",
-    "MCP",
-    "Typst",
-    "错别字检查"
-  ],
-  "activationEvents": [
-    "onLanguage:markdown",
-    "onLanguage:plaintext",
-    "onLanguage:ojson5",
-    "onLanguage:rjson5",
-    "onLanguage:tjson5",
-    "onFileSystem:andrea-outline",
-    "onCommand:andrea.openWritingDashboard",
-    "onCommand:andrea.openWritingDashboardWidget",
-    "onCommand:andrea.openRoleRelationshipGraph",
-    "onCommand:AndreaNovelHelper.openHello",
-    "onView:andrea.commentsExplorer",
-    "onView:andrea.commentsPanelView",
-    "onView:andrea.commentsManagerView",
-    "onWebviewPanel:andrea.writingDashboard",
-    "onWebviewPanel:andrea.writingDashboard.energy",
-    "onWebviewPanel:andrea.writingDashboard.heatmap",
-    "onWebviewPanel:andrea.writingDashboard.clock",
-    "onWebviewPanel:andrea.writingDashboard.profile",
-    "onWebviewPanel:andrea.writingDashboard.gantt",
-    "onWebviewPanel:andrea.writingDashboard.quadrant",
-    "onWebviewPanel:andrea.writingDashboard.plan",
-    "onWebviewPanel:andrea.writingDashboard.tasks",
-    "onWebviewPanel:andrea.writingDashboard.yearPlan",
-    "onWebviewPanel:andrea.writingDashboard.logs",
-    "onWebviewPanel:andrea.writingDashboard.timer",
-    "onWebviewPanel:andrea.roleRelationshipGraph",
-    "onWebviewPanel:andrea.guide",
-    "onWebviewPanel:andrea.guideDoc",
-    "onWebviewPanel:andrea.hello",
-    "onCommand:andrea.openWhatsNew",
-    "onWebviewPanel:whatsNew",
-    "onStartupFinished"
-  ],
-  "main": "./out/extension.js",
-  "contributes": {
-    "customEditors": [
-      {
-        "viewType": "andrea.roleJson5Editor",
-        "displayName": "角色 JSON5 编辑器",
-        "selector": [
-          {
-            "filenamePattern": "**/*.json5"
-          },
-          {
-            "filenamePattern": "**/*.ojson5"
-          }
-        ],
-        "priority": "default"
-      },
-      {
-        "viewType": "andrea.relationshipJson5Editor",
-        "displayName": "角色关系 JSON5 编辑器",
-        "selector": [
-          {
-            "filenamePattern": "**/*relationship*.json5"
-          },
-          {
-            "filenamePattern": "**/*.rjson5"
-          }
-        ],
-        "priority": "default"
-      },
-      {
-        "viewType": "andrea.timelineJson5Editor",
-        "displayName": "时间线 JSON5 编辑器",
-        "selector": [
-          {
-            "filenamePattern": "**/*.tjson5"
-          }
-        ],
-        "priority": "default"
-      },
-      {
-        "viewType": "andrea.timelineGanttJson5Editor",
-        "displayName": "时间线甘特图编辑器",
-        "selector": [
-          {
-            "filenamePattern": "**/*.tjson5"
-          }
-        ],
-        "priority": "option"
-      }
-    ],
-    "configurationDefaults": {
-      "[markdown]": {
-        "editor.quickSuggestions": {
-          "other": true,
-          "comments": true,
-          "strings": true
-        },
-        "editor.suggestOnTriggerCharacters": true,
-        "editor.wordBasedSuggestions": "allDocuments",
-        "editor.quickSuggestionsDelay": 0
-      },
-      "[plaintext]": {
-        "editor.quickSuggestions": {
-          "other": true,
-          "comments": true,
-          "strings": true
-        },
-        "editor.suggestOnTriggerCharacters": true,
-        "editor.wordBasedSuggestions": "allDocuments",
-        "editor.quickSuggestionsDelay": 0
-      }
-    },
-    "languages": [
-      {
-        "id": "wcignore",
-        "aliases": [
-          "WordCount Ignore",
-          "wcignore"
-        ],
-        "extensions": [
-          ".wcignore"
-        ],
-        "configuration": "./language-configuration.json"
-      },
-      {
-        "id": "ftignore",
-        "aliases": [
-          "FileTracking Ignore",
-          "ftignore"
-        ],
-        "extensions": [
-          ".ftignore"
-        ],
-        "configuration": "./language-configuration.json"
-      },
-      {
-        "id": "gitignore",
-        "aliases": [
-          "Git Ignore",
-          "gitignore"
-        ],
-        "filenames": [
-          ".gitignore"
-        ],
-        "configuration": "./language-configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "wcignore",
-        "scopeName": "source.wcignore",
-        "path": "./syntaxes/wcignore.tmLanguage.json"
-      },
-      {
-        "language": "ftignore",
-        "scopeName": "source.ftignore",
-        "path": "./syntaxes/ftignore.tmLanguage.json"
-      },
-      {
-        "language": "gitignore",
-        "scopeName": "source.gitignore.andrea",
-        "path": "./syntaxes/gitignore.tmLanguage.json"
-      },
-      {
-        "scopeName": "andrea.md.injection",
-        "path": "./syntaxes/andrea-md-injection.tmLanguage.json"
-      }
-    ],
-    "snippets": [
-      {
-        "language": "markdown",
-        "path": "./snippets/def-md.json"
-      },
-      {
-        "language": "plaintext",
-        "path": "./snippets/def-txt.json"
-      }
-    ],
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "AndreaNovelHelperSidebar",
-          "title": "%sidebar.anh.title%",
-          "icon": "images/anh_logo_dark.svg",
-          "when": "andrea.anh.enabled"
-        },
-        {
-          "id": "AndreaCommentsSidebar",
-          "title": "%sidebar.comments.title%",
-          "icon": "$(comment-discussion)",
-          "when": "andrea.anh.enabled"
-        },
-        {
-          "id": "AndreaWebDAVSidebar",
-          "title": "%sidebar.webdav.title%",
-          "icon": "$(cloud)",
-          "when": "andrea.anh.enabled"
-        },
-        {
-          "id": "AndreaScriptsSidebar",
-          "title": "%sidebar.scripts.title%",
-          "icon": "$(run)",
-          "when": "andrea.anh.enabled"
-        },
-        {
-          "id": "AndreaSettingsSidebar",
-          "title": "%sidebar.settings.title%",
-          "icon": "$(gear)",
-          "when": "andrea.anh.enabled"
-        }
-      ]
-    },
-    "textDocumentContentProviders": [
-      {
-        "scheme": "andrea-outline",
-        "language": "markdown"
-      }
-    ],
-    "commands": [
-      {
-        "command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
-        "title": "切换：使用角色卡管理器打开json5"
-      },
-      {
-        "command": "andrea.roleCardManager.open",
-        "title": "打开角色卡管理器测试页面"
-      },
-      {
-        "command": "andrea.ensureEnterOverrides",
-        "title": "%command.andrea.ensureEnterOverrides.title%",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.toggleSmartExit",
-        "title": "%command.andrea.toggleSmartExit.title%"
-      },
-      {
-        "command": "andrea.smartEnter",
-        "title": "%command.andrea.smartEnter.title%"
-      },
-      {
-        "command": "andrea.formatDocument",
-        "title": "%command.andrea.formatDocument.title%"
-      },
-      {
-        "command": "andrea.formatDocument.addBlanks",
-        "title": "%command.andrea.formatDocument.addBlanks.title%"
-      },
-      {
-        "command": "andrea.quickSettings",
-        "title": "%command.andrea.quickSettings.title%"
-      },
-      {
-        "command": "andrea.openGraphicalQuickSettings",
-        "title": "打开图形化快速设置",
-        "category": "Andrea Novel Helper",
-        "icon": "$(settings-gear)"
-      },
-      {
-        "command": "andrea.openSettingsWizard",
-        "title": "%command.andrea.openSettingsWizard.title%",
-        "category": "Andrea Novel Helper",
-        "icon": "$(wand)"
-      },
-      {
-        "command": "andrea.openProjectSettings",
-        "title": "打开项目设置",
-        "category": "Andrea Novel Helper",
-        "icon": "$(settings-gear)"
-      },
-      {
-        "command": "andrea.openWritingDashboard",
-        "title": "打开创作工作台",
-        "category": "Andrea Novel Helper",
-        "icon": "$(dashboard)"
-      },
-      {
-        "command": "andrea.openWritingDashboardWidget",
-        "title": "独立打开创作工作台组件",
-        "category": "Andrea Novel Helper",
-        "icon": "$(window)"
-      },
-      {
-        "command": "andrea.openRoleRelationshipGraph",
-        "title": "打开角色关系图谱",
-        "category": "Andrea Novel Helper",
-        "icon": "$(graph)"
-      },
-      {
-        "command": "andrea.configureMilestones",
-        "title": "%command.andrea.configureMilestones.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openTimeStats",
-        "title": "打开写作统计仪表板",
-        "category": "Andrea Novel Helper",
-        "icon": "$(graph)"
-      },
-      {
-        "command": "AndreaNovelHelper.exportTimeStatsCSV",
-        "title": "导出写作时间统计 CSV",
-        "category": "Andrea Novel Helper",
-        "icon": "$(file-code)"
-      },
-      {
-        "command": "andrea.toggleIndentFirst",
-        "title": "%command.andrea.toggleIndentFirst.title%"
-      },
-      {
-        "command": "andrea.toggleTrimTrailing",
-        "title": "%command.andrea.toggleTrimTrailing.title%"
-      },
-      {
-        "command": "andrea.changeBlankLines",
-        "title": "%command.andrea.changeBlankLines.title%"
-      },
-      {
-        "command": "andrea.changeIndentSize",
-        "title": "%command.andrea.changeIndentSize.title%"
-      },
-      {
-        "command": "andrea.manageEditorFontFamily",
-        "title": "%command.andrea.manageEditorFontFamily.title%"
-      },
-      {
-        "command": "andrea.toggleAutoPairs",
-        "title": "%command.andrea.toggleAutoPairs.title%"
-      },
-      {
-        "command": "andrea.toggleSmartEnter",
-        "title": "%command.andrea.toggleSmartEnter.title%"
-      },
-      {
-        "command": "myPreview.open",
-        "title": "%command.myPreview.open.title%",
-        "icon": {
-          "light": "images/preview_light.svg",
-          "dark": "images/preview_dark.svg"
-        }
-      },
-      {
-        "command": "andrea.typst.exportCurrent",
-        "title": "导出：使用Typst模板为PDF/图片"
-      },
-      {
-        "command": "andrea.typst.exportFromExplorer",
-        "title": "导出：使用Typst模板",
-        "icon": {
-          "light": "$(export)",
-          "dark": "$(export)"
-        }
-      },
-      {
-        "command": "AndreaNovelHelper.openTypstPreview",
-        "title": "打开Typst实时预览",
-        "icon": {
-          "light": "$(preview)",
-          "dark": "$(preview)"
-        }
-      },
-      {
-        "command": "AndreaNovelHelper.changeTypstTemplate",
-        "title": "切换Typst模板",
-        "icon": {
-          "light": "$(settings)",
-          "dark": "$(settings)"
-        }
-      },
-      {
-        "command": "myPreview.copyPlainText",
-        "title": "%command.myPreview.copyPlainText.title%"
-      },
-      {
-        "command": "andrea.comments.open",
-        "title": "%command.comments.open.title%",
-        "icon": {
-          "light": "images/comments_light.svg",
-          "dark": "images/comments_dark.svg"
-        }
-      },
-      {
-        "command": "andrea.comments.add",
-        "title": "%command.comments.add.title%"
-      },
-      {
-        "command": "andrea.comments.resolve",
-        "title": "%command.comments.resolve.title%"
-      },
-      {
-        "command": "andrea.comments.reopen",
-        "title": "%command.comments.reopen.title%"
-      },
-      {
-        "command": "andrea.commentsExplorer.toggleStatus",
-        "title": "%command.commentsExplorer.toggleStatus.title%",
-        "icon": {
-          "light": "$(check)",
-          "dark": "$(check)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.rebindFileToDocument",
-        "title": "%command.commentsExplorer.rebindFileToDocument.title%",
-        "icon": {
-          "light": "$(file-symlink-file)",
-          "dark": "$(file-symlink-file)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.openComment",
-        "title": "%command.commentsExplorer.openComment.title%",
-        "icon": {
-          "light": "$(go-to-file)",
-          "dark": "$(go-to-file)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.refresh",
-        "title": "%command.commentsExplorer.refresh.title%",
-        "icon": {
-          "light": "$(refresh)",
-          "dark": "$(refresh)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.search",
-        "title": "%command.commentsExplorer.search.title%",
-        "icon": {
-          "light": "$(search)",
-          "dark": "$(search)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.filterByStatus",
-        "title": "%command.commentsExplorer.filterByStatus.title%",
-        "icon": {
-          "light": "$(filter)",
-          "dark": "$(filter)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.clearFilter",
-        "title": "%command.commentsExplorer.clearFilter.title%",
-        "icon": {
-          "light": "$(clear-all)",
-          "dark": "$(clear-all)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.exportComments",
-        "title": "%command.commentsExplorer.exportComments.title%",
-        "icon": {
-          "light": "$(export)",
-          "dark": "$(export)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.exportToMarkdown",
-        "title": "%command.commentsExplorer.exportToMarkdown.title%",
-        "icon": {
-          "light": "$(markdown)",
-          "dark": "$(markdown)"
-        }
-      },
-      {
-        "command": "andrea.commentsExplorer.exportToJson",
-        "title": "%command.commentsExplorer.exportToJson.title%",
-        "icon": {
-          "light": "$(json)",
-          "dark": "$(json)"
-        }
-      },
-      {
-        "command": "andrea.scripts.openMcpConfig",
-        "title": "打开 MCP 配置",
-        "icon": "$(gear)"
-      },
-      {
-        "command": "andrea.scripts.toggleMcpServers",
-        "title": "启用/禁用 MCP 服务器",
-        "icon": "$(plug)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.copilot.exportPromptsToWorkspace",
-        "title": "导出内置 Copilot 提示到当前项目",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.toggleSingleServer",
-        "title": "切换 MCP 服务器启用状态",
-        "icon": "$(toggle-layout)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.reloadExtensions",
-        "title": "重新加载脚本扩展",
-        "icon": "$(refresh)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.selectPlainTextProcessor",
-        "title": "选择默认纯文本处理器",
-        "icon": "$(settings-gear)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.selectTypstRenderer",
-        "title": "选择默认 Typst 渲染器",
-        "icon": "$(symbol-method)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.runPlainTextProcessor",
-        "title": "使用脚本处理器处理当前文档",
-        "icon": "$(symbol-method)",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.runWithServers",
-        "title": "选择服务器运行",
-        "icon": "$(play)"
-      },
-      {
-        "command": "WordCount.exportTxt",
-        "title": "%command.wordCount.exportTxt.title%"
-      },
-      {
-        "command": "WordCount.exportTxtWithProcessor",
-        "title": "导出为 TXT（选择处理器）"
-      },
-      {
-        "command": "WordCount.copyPlainText",
-        "title": "%command.wordCount.copyPlainText.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.addRoleFromSelection",
-        "title": "%command.addRoleFromSelection.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.refreshRoles",
-        "title": "%command.refreshRoles.title%"
-      },
-      {
-        "command": "andrea.configureAllRoles",
-        "title": "配置：全部角色显示"
-      },
-      {
-        "command": "andrea.configureDocRoles",
-        "title": "配置：当前文章角色显示"
-      },
-      {
-        "command": "AndreaNovelHelper.addSensitiveWord",
-        "title": "%command.addSensitiveWord.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.refreshSensitiveWords",
-        "title": "%command.refreshSensitiveWords.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.addVocabulary",
-        "title": "%command.addVocabulary.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.refreshVocabulary",
-        "title": "%command.refreshVocabulary.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openDoubleOutline",
-        "title": "%command.openDoubleOutline.title%",
-        "icon": {
-          "light": "images/checklist_light.svg",
-          "dark": "images/checklist_dark.svg"
-        }
-      },
-      {
-        "command": "AndreaNovelHelper.openOutlinePicker",
-        "title": "ANH:打开大纲 New",
-        "icon": {
-          "light": "images/checklist_light.svg",
-          "dark": "images/checklist_dark.svg"
-        }
-      },
-      {
-        "command": "AndreaNovelHelper.redirectOutlineHere",
-        "title": "ANH:打开新大纲窗体",
-        "icon": {
-          "light": "images/checklist_light.svg",
-          "dark": "images/checklist_dark.svg"
-        }
-      },
-      {
-        "command": "AndreaNovelHelper.refreshOutlineDir",
-        "title": "%command.refreshOutlineDir.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.refreshOutlineFile",
-        "title": "%command.refreshOutlineFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openFile",
-        "title": "%command.openFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openProjectConfigFile",
-        "title": "打开项目设置文件"
-      },
-      {
-        "command": "AndreaNovelHelper.deleteNode",
-        "title": "%command.deleteNode.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createCharacterGallery",
-        "title": "%command.createCharacterGallery.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createSensitiveWords",
-        "title": "%command.createSensitiveWords.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createVocabulary",
-        "title": "%command.createVocabulary.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createRoleFile",
-        "title": "%command.createRoleFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createRelationshipFile",
-        "title": "%command.createRelationshipFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createTimelineFile",
-        "title": "%command.createTimelineFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createSubPackage",
-        "title": "%command.createSubPackage.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.renamePackage",
-        "title": "%command.renamePackage.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.createRegexPatterns",
-        "title": "%command.createRegexPatterns.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openWith",
-        "title": "%command.openWith.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.revealInExplorer",
-        "title": "%command.revealInExplorer.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.toggleMarkdownToolbar",
-        "title": "%command.toggleMarkdownToolbar.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.showMarkdownFormatMenu",
-        "title": "%command.showMarkdownFormatMenu.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.applyMarkdownFormat",
-        "title": "%command.applyMarkdownFormat.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.showFileTrackingStats",
-        "title": "%command.showFileTrackingStats.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.fileTracking.repairPathKeys",
-        "title": "%command.fileTracking.repairPathKeys.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.timeStats.repairSummary",
-        "title": "%command.timeStats.repairSummary.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.cleanupMissingFiles",
-        "title": "%command.cleanupMissingFiles.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.exportTrackingData",
-        "title": "%command.exportTrackingData.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.fileTracker.openShardForFile",
-        "title": "%command.fileTracker.openShardForFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.gcFileTracking",
-        "title": "%command.gcFileTracking.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.createNewFile",
-        "title": "%command.wordCount.createNewFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.createNewFolder",
-        "title": "%command.wordCount.createNewFolder.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.insertFileAbove",
-        "title": "%command.wordCount.insertFileAbove.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.insertFileBelow",
-        "title": "%command.wordCount.insertFileBelow.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.insertFolderAbove",
-        "title": "%command.wordCount.insertFolderAbove.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.insertFolderBelow",
-        "title": "%command.wordCount.insertFolderBelow.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.open",
-        "title": "%command.wordCount.open.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.revealInOS",
-        "title": "%command.wordCount.revealInOS.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.rename",
-        "title": "%command.wordCount.rename.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.delete",
-        "title": "%command.wordCount.delete.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.exportTypst",
-        "title": "导出：使用Typst模板"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.toggleManualOrdering",
-        "title": "%command.wordCount.toggleManualOrdering.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.enableManualOrdering",
-        "title": "%command.wordCount.enableManualOrdering.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.disableManualOrdering",
-        "title": "%command.wordCount.disableManualOrdering.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.generateIndexFromName",
-        "title": "%command.wordCount.generateIndexFromName.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.clearIndex",
-        "title": "%command.wordCount.clearIndex.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.setIndexManual",
-        "title": "%command.wordCount.setIndexManual.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.bulkGenerateIndices",
-        "title": "%command.wordCount.bulkGenerateIndices.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.forceRecountAll",
-        "title": "%command.wordCount.forceRecountAll.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.forceRecountHere",
-        "title": "%command.wordCount.forceRecountHere.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.rescanResourceFilesInFolder",
-        "title": "%command.wordCount.rescanResourceFilesInFolder.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.copy",
-        "title": "%command.wordCount.copy.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.cut",
-        "title": "%command.wordCount.cut.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wordCount.paste",
-        "title": "%command.wordCount.paste.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.package.copy",
-        "title": "%command.package.copy.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.package.cut",
-        "title": "%command.package.cut.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.package.paste",
-        "title": "%command.package.paste.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.package.rescanExternalFolders",
-        "title": "%command.package.rescanExternalFolders.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.package.showExternalScanReport",
-        "title": "%command.package.showExternalScanReport.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.setupGitIdentity",
-        "title": "%command.setupGitIdentity.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.openSetupWizard",
-        "title": "%command.openSetupWizard.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wizard.checkGit",
-        "title": "%command.wizard.checkGit.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wizard.openGitDownload",
-        "title": "%command.wizard.openGitDownload.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wizard.checkGitUser",
-        "title": "%command.wizard.checkGitUser.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.wizard.configureGitUser",
-        "title": "%command.wizard.configureGitUser.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.testGitDownloadLink",
-        "title": "%command.testGitDownloadLink.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.simulateNoGit",
-        "title": "%command.simulateNoGit.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.projectInitWizard",
-        "title": "%command.projectInitWizard.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.projectInitWizard.graphical",
-        "title": "打开图形化项目初始化向导",
-        "category": "Andrea Novel Helper",
-        "icon": "$(rocket)"
-      },
-      {
-        "command": "AndreaNovelHelper.showGuide",
-        "title": "打开功能引导",
-        "category": "Andrea Novel Helper",
-        "icon": "$(book)"
-      },
-      {
-        "command": "AndreaNovelHelper.openHello",
-        "title": "打开 ANH Hello 首页",
-        "category": "Andrea Novel Helper",
-        "icon": "$(home)"
-      },
-      {
-        "command": "AndreaNovelHelper.showGuideDoc",
-        "title": "%command.showGuideDoc.title%",
-        "category": "Andrea Novel Helper",
-        "icon": "$(book)"
-      },
-      {
-        "command": "AndreaNovelHelper.generateLookupKeysForCurrentFile",
-        "title": "为当前角色文件生成查询键",
-        "category": "Andrea Novel Helper",
-        "icon": "$(symbol-key)"
-      },
-      {
-        "command": "AndreaNovelHelper.disableWorkspace",
-        "title": "%command.disableWorkspace.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.enableWorkspace",
-        "title": "%command.enableWorkspace.title%"
-      },
-      {
-        "command": "andrea.refreshMaioStatus",
-        "title": "%command.refreshMaioStatus.title%",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.detectTxtRoleFiles",
-        "title": "检测 TXT 角色档案并迁移",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.migrateTxtRoleFile",
-        "title": "迁移 TXT 角色档案",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.typo.scanDocument",
-        "title": "扫描错别字（未扫描段落）",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.typo.rescanDocument",
-        "title": "重新扫描错别字（强制全量）",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.typo.rescanCurrentFile",
-        "title": "重新扫描当前文件错别字",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.typo.stopAllRequests",
-        "title": "强制停止所有错别字扫描请求",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.typo.translateSelection",
-        "title": "翻译选中文本（LLM）",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.webdav.manageAccounts",
-        "title": "%command.webdav.manageAccounts.title%"
-      },
-      {
-        "command": "andrea.webdav.syncNow",
-        "title": "%command.webdav.syncNow.title%"
-      },
-      {
-        "command": "andrea.webdav.openPanel",
-        "title": "%command.webdav.openPanel.title%"
-      },
-      {
-        "command": "andrea.webdav.refreshFiles",
-        "title": "%command.webdav.refreshFiles.title%"
-      },
-      {
-        "command": "andrea.webdav.openFile",
-        "title": "%command.webdav.openFile.title%"
-      },
-      {
-        "command": "andrea.webdav.uploadFile",
-        "title": "%command.webdav.uploadFile.title%"
-      },
-      {
-        "command": "andrea.webdav.deleteFile",
-        "title": "%command.webdav.deleteFile.title%"
-      },
-      {
-        "command": "andrea.webdav.createFolder",
-        "title": "%command.webdav.createFolder.title%"
-      },
-      {
-        "command": "andrea.webdav.renameFile",
-        "title": "%command.webdav.renameFile.title%"
-      },
-      {
-        "command": "andrea.webdav.copyFile",
-        "title": "%command.webdav.copyFile.title%"
-      },
-      {
-        "command": "AndreaNovelHelper.database.switchBackend",
-        "title": "切换数据库后端",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.database.migrate",
-        "title": "运行数据库迁移",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.database.showStatus",
-        "title": "查看数据库状态",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.database.healthCheck",
-        "title": "数据库健康检查",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.database.optimize",
-        "title": "优化数据库",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.database.compare",
-        "title": "比较数据库后端数据",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.roleUsage.rebuildIndex",
-        "title": "Andrea Novel Helper: 重新索引角色引用",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.roleUsage.clearIndex",
-        "title": "Andrea Novel Helper: 清除角色引用索引",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.fileTracking.cleanAbsolutePaths",
-        "title": "Andrea Novel Helper: 清理文件追踪数据库中的绝对路径",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.openRoleHeatmap",
-        "title": "打开角色引用热力图",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.circlePacking.getRoleReferenceData",
-        "title": "获取角色引用数据",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.circlePacking.getFileTimelineData",
-        "title": "获取文件时间线数据",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.circlePacking.getCompleteDataset",
-        "title": "获取完整数据集",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.circlePacking.exportToJson",
-        "title": "导出 Circle Packing 数据到 JSON",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "AndreaNovelHelper.circlePacking.debugPrintStats",
-        "title": "输出 Circle Packing 数据统计",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.scripts.refresh",
-        "title": "刷新脚本列表",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "andrea.scripts.open",
-        "title": "打开脚本"
-      },
-      {
-        "command": "andrea.scripts.run",
-        "title": "运行脚本",
-        "icon": "$(run)"
-      },
-      {
-        "command": "andrea.scripts.newScript",
-        "title": "新建脚本",
-        "icon": "$(new-file)"
-      },
-      {
-        "command": "andrea.scripts.deleteScript",
-        "title": "删除脚本"
-      },
-      {
-        "command": "andrea.scripts.renameScript",
-        "title": "重命名脚本"
-      },
-      {
-        "command": "andrea.scripts.openFolder",
-        "title": "打开脚本文件夹",
-        "icon": "$(folder-opened)"
-      },
-      {
-        "command": "andrea-novel-helper.generateRandomNames",
-        "title": "生成随机名字",
-        "category": "Andrea Novel Helper",
-        "icon": "$(symbol-misc)"
-      },
-      {
-        "command": "andrea-novel-helper.quickGenerateName",
-        "title": "快速生成名字",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea-novel-helper.showNameGeneratorStats",
-        "title": "显示名字生成统计",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea-novel-helper.generateRandomCharacter",
-        "title": "随机生成角色",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea-novel-helper.generateStepByStepCharacter",
-        "title": "随机分步生成角色（姓氏+名字）",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.autoScroll.toggle",
-        "title": "切换自动滚动",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.autoScroll.setRatio",
-        "title": "设置自动滚动比例",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.autoScroll.scrollToEnd",
-        "title": "滚动到文档末尾",
-        "category": "Andrea Novel Helper"
-      },
-      {
-        "command": "andrea.openWhatsNew",
-        "title": "打开 What's New",
-        "category": "Andrea Novel Helper",
-        "icon": "$(rocket)"
-      },
-      {
-        "command": "andrea.copilot.exportMcpStdioScript",
-        "title": "释放 MCP stdio 代理桥脚本",
-        "category": "Andrea Novel Helper",
-        "icon": "$(terminal)"
-      }
-    ],
-    "walkthroughs": [
-      {
-        "id": "andreaNovelHelper.setup",
-        "title": "%walkthrough.andrea.setup.title%",
-        "description": "%walkthrough.andrea.setup.description%",
-        "steps": [
-          {
-            "id": "anh.step.open",
-            "title": "%walkthrough.anh.step.open.title%",
-            "description": "%walkthrough.anh.step.open.description%",
-            "media": {
-              "markdown": "media/walkthrough/step0_intro.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.openSetupWizard"
-            ]
-          },
-          {
-            "id": "anh.step.checkGit",
-            "title": "%walkthrough.anh.step.checkGit.title%",
-            "description": "%walkthrough.anh.step.checkGit.description%",
-            "media": {
-              "markdown": "media/walkthrough/step1_checkGit.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.wizard.checkGit"
-            ]
-          },
-          {
-            "id": "anh.step.installGit",
-            "title": "%walkthrough.anh.step.installGit.title%",
-            "description": "%walkthrough.anh.step.installGit.description%",
-            "media": {
-              "markdown": "media/walkthrough/step2_installGit.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.wizard.openGitDownload"
-            ]
-          },
-          {
-            "id": "anh.step.checkUser",
-            "title": "%walkthrough.anh.step.checkUser.title%",
-            "description": "%walkthrough.anh.step.checkUser.description%",
-            "media": {
-              "markdown": "media/walkthrough/step3_checkUser.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.wizard.checkGitUser"
-            ]
-          },
-          {
-            "id": "anh.step.configureUser",
-            "title": "%walkthrough.anh.step.configureUser.title%",
-            "description": "%walkthrough.anh.step.configureUser.description%",
-            "media": {
-              "markdown": "media/walkthrough/step4_configUser.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.wizard.configureGitUser"
-            ]
-          },
-          {
-            "id": "anh.step.recheck",
-            "title": "%walkthrough.anh.step.recheck.title%",
-            "description": "%walkthrough.anh.step.recheck.description%",
-            "media": {
-              "markdown": "media/walkthrough/step5_recheck.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.wizard.checkGitUser"
-            ]
-          },
-          {
-            "id": "anh.step.vscodeSidebar",
-            "title": "%walkthrough.anh.step.vscodeSidebar.title%",
-            "description": "%walkthrough.anh.step.vscodeSidebar.description%",
-            "media": {
-              "markdown": "media/walkthrough/step6_vscodeSidebar.md"
-            },
-            "completionEvents": [
-              "onCommand:workbench.view.explorer"
-            ]
-          },
-          {
-            "id": "anh.step.anhFeatures",
-            "title": "%walkthrough.anh.step.anhFeatures.title%",
-            "description": "%walkthrough.anh.step.anhFeatures.description%",
-            "media": {
-              "markdown": "media/walkthrough/step7_anhFeatures.md"
-            },
-            "completionEvents": [
-              "onCommand:AndreaNovelHelper.showGuideDoc"
-            ]
-          },
-          {
-            "id": "anh.step.finish",
-            "title": "%walkthrough.anh.step.finish.title%",
-            "description": "%walkthrough.anh.step.finish.description%",
-            "media": {
-              "markdown": "media/walkthrough/step8_finish.md"
-            }
-          }
-        ]
-      }
-    ],
-    "configuration": {
-      "type": "object",
-      "title": "%config.title%",
-      "properties": {
-        "AndreaNovelHelper.typo.applyPartialDecorationsImmediately": {
-          "anhName": "即时错别字高亮",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "在LLM分段结果(partial)阶段是否立刻应用错别字高亮（默认否，仅在最终结果阶段应用，避免\"瞬间出现又消失\"的闪烁）"
-        },
-        "AndreaNovelHelper.writingDashboard.widget.showHeader": {
-          "anhName": "创作工作台独立组件显示顶栏",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "独立打开创作工作台组件时是否显示顶部标题栏和“打开工作台”按钮。关闭后组件内容会占满整个 Webview。"
-        },
-        "AndreaNovelHelper.typo.suppressRolesMode": {
-          "anhName": "角色抑制模式",
-          "type": "string",
-          "enum": [
-            "none",
-            "roleNameExact",
-            "regexContain",
-            "nonSensitiveIntersect"
-          ],
-          "default": "roleNameExact",
-          "markdownDescription": "错别字标记的角色抑制模式：none（不抑制）；roleNameExact（仅当错字文本与某角色名完全相等时抑制，忽略正则角色）；regexContain（仅当被正则表达式角色完全包含整段时抑制）；nonSensitiveIntersect（旧版：与任意非敏感角色相交则抑制）"
-        },
-        "AndreaNovelHelper.translate.targets": {
-          "anhName": "翻译目标语言列表",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "中文",
-            "英文",
-            "日语",
-            "德语",
-            "法语",
-            "韩语",
-            "繁体中文",
-            "拉丁语",
-            "希腊语"
-          ],
-          "markdownDescription": "右键翻译的可选目标语言列表"
-        },
-        "AndreaNovelHelper.translate.defaultTarget": {
-          "anhName": "默认翻译目标语言",
-          "type": "string",
-          "enum": [
-            "中文",
-            "英文",
-            "日语",
-            "德语",
-            "法语",
-            "韩语",
-            "繁体中文",
-            "拉丁语",
-            "希腊语"
-          ],
-          "default": "中文",
-          "markdownDescription": "翻译默认目标语言（与可选列表配合使用）"
-        },
-        "AndreaNovelHelper.translate.alwaysUseDefaultTarget": {
-          "anhName": "跳过语言选择",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "跳过语言选择，直接使用默认目标语言"
-        },
-        "AndreaNovelHelper.translate.defaultAction": {
-          "anhName": "翻译结果处理方式",
-          "type": "string",
-          "enum": [
-            "replaceSelection",
-            "openInNewTab",
-            "copyToClipboard"
-          ],
-          "default": "replaceSelection",
-          "markdownDescription": "翻译结果默认处理方式：替换选区/新标签页/复制到剪贴板"
-        },
-        "AndreaNovelHelper.translate.alwaysUseDefaultAction": {
-          "anhName": "跳过处理方式选择",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "跳过处理方式选择，直接使用默认处理方式"
-        },
-        "AndreaNovelHelper.comments.authorName": {
-          "anhName": "批注作者名",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "批注作者显示名（留空则使用系统用户名）"
-        },
-        "AndreaNovelHelper.comments.showInOverviewRuler": {
-          "anhName": "显示概览标尺",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "在编辑器右侧概览标尺中显示批注范围标记"
-        },
-        "AndreaNovelHelper.comments.style.mode": {
-          "anhName": "批注展示风格",
-          "type": "string",
-          "enum": [
-            "underline",
-            "highlight"
-          ],
-          "default": "underline",
-          "markdownDescription": "批注范围展示风格：下划线或高亮背景"
-        },
-        "AndreaNovelHelper.comments.style.underlineStyle": {
-          "anhName": "下划线样式",
-          "type": "string",
-          "enum": [
-            "solid",
-            "wavy",
-            "dotted",
-            "dashed"
-          ],
-          "default": "solid",
-          "markdownDescription": "下划线样式"
-        },
-        "AndreaNovelHelper.comments.style.underlineColor": {
-          "anhName": "下划线颜色",
-          "type": "string",
-          "default": "#0e639c",
-          "markdownDescription": "下划线颜色（CSS 颜色）"
-        },
-        "AndreaNovelHelper.comments.style.highlightOffset": {
-          "anhName": "高亮背景强度",
-          "type": "number",
-          "default": 0.06,
-          "minimum": 0,
-          "maximum": 0.5,
-          "markdownDescription": "高亮背景强度：在当前主题背景上叠加的透明度偏移（亮色为黑、暗色为白）"
-        },
-        "AndreaNovelHelper.comments.hoverEnabled": {
-          "anhName": "悬停显示批注",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "鼠标悬停批注范围时显示批注内容"
-        },
-        "AndreaNovelHelper.comments.showGutterInfo": {
-          "anhName": "显示行号图标",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "在有批注的行号区域显示信息图标，便于快速定位（可关闭）"
-        },
-        "AndreaNovelHelper.comments.relink.strict": {
-          "anhName": "严格重定位",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "严格重定位：仅在上下文吻合或距原位置不远时才回钩；否则视为该范围已缺失，不再兜底到段落。"
-        },
-        "AndreaNovelHelper.comments.cleanup.mode": {
-          "anhName": "清理模式",
-          "type": "string",
-          "enum": [
-            "delete-thread",
-            "delete-range",
-            "mark-resolved",
-            "none"
-          ],
-          "default": "delete-thread",
-          "markdownDescription": "当所有范围均无法重定位时的处理：delete-thread（软删除整线程），delete-range（仅清空范围），mark-resolved（标记为已解决），none（不处理）。"
-        },
-        "AndreaNovelHelper.allRoles.syncWithDocRoles": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "同步文档角色设置",
-          "markdownDescription": "全部角色是否与\"当前文章角色\"显示设置保持同步。开启则复用 AndreaNovelHelper.docRoles.* 配置；关闭则使用下方 allRoles.* 专属配置。"
-        },
-        "AndreaNovelHelper.allRoles.groupBy": {
-          "type": "string",
-          "enum": [
-            "affiliation",
-            "type",
-            "none"
-          ],
-          "default": "affiliation",
-          "anhName": "分组依据",
-          "markdownDescription": "全部角色的分组依据：affiliation / type / none"
-        },
-        "AndreaNovelHelper.allRoles.respectAffiliation": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "遵循角色归属",
-          "markdownDescription": "是否遵循角色归属字段"
-        },
-        "AndreaNovelHelper.allRoles.respectType": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "遵循角色类型",
-          "markdownDescription": "是否遵循角色类型字段"
-        },
-        "AndreaNovelHelper.allRoles.primaryGroup": {
-          "type": "string",
-          "enum": [
-            "affiliation",
-            "type"
-          ],
-          "default": "affiliation",
-          "anhName": "首要分组",
-          "markdownDescription": "第一级别分组（归属优先/类型优先）"
-        },
-        "AndreaNovelHelper.allRoles.typeOrder": {
-          "type": "array",
-          "default": [
-            "主角",
-            "主要角色",
-            "反派",
-            "配角",
-            "联动角色",
-            "词汇",
-            "敏感词",
-            "正则表达式",
-            "unknown"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "anhName": "角色类型排序",
-          "markdownDescription": "全部角色视图中的角色类型排序。列表靠前的类型会优先显示；未列出的类型会排在后面并继续按名称自然排序。开启“同步文档角色设置”时，全部角色会复用当前文章角色的排序。"
-        },
-        "AndreaNovelHelper.allRoles.customGroups": {
-          "anhName": "自定义分组规则",
-          "type": "array",
-          "default": [
-            {
-              "name": "词汇敏感词",
-              "matchType": "type",
-              "patterns": [
-                "词汇",
-                "敏感词",
-                "正则表达式"
-              ]
-            },
-            {
-              "name": "主要角色",
-              "matchType": "type",
-              "patterns": [
-                "主角",
-                "重要",
-                "主要"
-              ]
-            },
-            {
-              "name": "配角",
-              "matchType": "type",
-              "patterns": [
-                "配角",
-                "次要",
-                "其他"
-              ]
-            }
-          ],
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "matchType": {
-                "type": "string",
-                "enum": [
-                  "affiliation",
-                  "type"
-                ]
-              },
-              "patterns": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "name",
-              "matchType",
-              "patterns"
-            ]
-          },
-          "markdownDescription": "全部角色的自定义分组规则"
-        },
-        "AndreaNovelHelper.allRoles.useCustomGroups": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "启用自定义分组",
-          "markdownDescription": "是否启用全部角色的自定义分组规则"
-        },
-        "AndreaNovelHelper.wordCount.referenceVisibleExtensions": {
-          "anhName": "参考文件扩展名",
-          "type": "array",
-          "default": [
-            "tjson5",
-            "png",
-            "jpg",
-            "jpeg",
-            "gif",
-            "bmp",
-            "svg",
-            "webp",
-            "tiff",
-            "ico",
-            "pdf",
-            "doc",
-            "docx",
-            "docm",
-            "dotx",
-            "dotm",
-            "xls",
-            "xlsx",
-            "xlsm",
-            "xltx",
-            "xltm",
-            "xlsb",
-            "csv",
-            "ods",
-            "odt",
-            "ppt",
-            "pptx",
-            "pptm",
-            "potx",
-            "potm",
-            "pps",
-            "ppsx",
-            "ppsm",
-            "odt",
-            "ods",
-            "odp",
-            "odg",
-            "odf",
-            "rtf",
-            "wps",
-            "et",
-            "dps",
-            "drawio",
-            "dio",
-            "vsdx",
-            "vsd",
-            "vssx",
-            "vstx",
-            "lucidchart",
-            "mmd",
-            "plantuml",
-            "puml",
-            "mindnode",
-            "xmind",
-            "mm",
-            "freemind"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "在字数统计树中显示为参考资料但不计入统计的文件扩展名列表。默认包含常见图片、PDF、Word/Excel/PowerPoint 等。"
-        },
-        "AndreaNovelHelper.docRoles.groupBy": {
-          "type": "string",
-          "enum": [
-            "affiliation",
-            "type",
-            "none"
-          ],
-          "default": "affiliation",
-          "anhName": "分组依据",
-          "markdownDescription": "当前文章角色的分组依据：**affiliation** (归属)、**type** (类型) 或 **none** (不分组)"
-        },
-        "AndreaNovelHelper.docRoles.respectAffiliation": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "遵循角色归属",
-          "markdownDescription": "是否遵循角色的归属字段进行分组显示"
-        },
-        "AndreaNovelHelper.docRoles.respectType": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "遵循角色类型",
-          "markdownDescription": "是否遵循角色的类型字段进行分组显示"
-        },
-        "AndreaNovelHelper.docRoles.primaryGroup": {
-          "type": "string",
-          "enum": [
-            "affiliation",
-            "type"
-          ],
-          "default": "affiliation",
-          "anhName": "首要分组",
-          "markdownDescription": "第一级别分组依据：**affiliation** (归属) 或 **type** (类型)"
-        },
-        "AndreaNovelHelper.docRoles.typeOrder": {
-          "type": "array",
-          "default": [
-            "主角",
-            "主要角色",
-            "反派",
-            "配角",
-            "联动角色",
-            "词汇",
-            "敏感词",
-            "正则表达式",
-            "unknown"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "anhName": "角色类型排序",
-          "markdownDescription": "当前文章角色视图中的角色类型排序。列表靠前的类型会优先显示；未列出的类型会排在后面并继续按名称自然排序。默认让“主角”显示在“配角”之前。"
-        },
-        "AndreaNovelHelper.docRoles.customGroups": {
-          "anhName": "自定义分组规则",
-          "type": "array",
-          "default": [
-            {
-              "name": "词汇敏感词",
-              "matchType": "type",
-              "patterns": [
-                "词汇",
-                "敏感词",
-                "正则表达式"
-              ]
-            },
-            {
-              "name": "主要角色",
-              "matchType": "type",
-              "patterns": [
-                "主角",
-                "重要",
-                "主要"
-              ]
-            },
-            {
-              "name": "配角",
-              "matchType": "type",
-              "patterns": [
-                "配角",
-                "次要",
-                "其他"
-              ]
-            }
-          ],
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "分组显示名称"
-              },
-              "matchType": {
-                "type": "string",
-                "enum": [
-                  "affiliation",
-                  "type"
-                ],
-                "description": "匹配字段类型"
-              },
-              "patterns": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "匹配模式列表（支持部分匹配）"
-              }
-            },
-            "required": [
-              "name",
-              "matchType",
-              "patterns"
-            ]
-          },
-          "markdownDescription": "自定义角色分组规则列表，用于创建第一级别的自定义分组"
-        },
-        "AndreaNovelHelper.docRoles.useCustomGroups": {
-          "anhName": "启用自定义分组",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "是否启用自定义分组规则（优先级高于 groupBy 设置）"
-        },
-        "AndreaNovelHelper.roles.details.showColorOnValue": {
-          "anhName": "显示颜色预览",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "在角色详情的值行上显示颜色预览色块（默认: true）。此设置影响全部角色与当前文章角色视图，除非对应的 allRoles/docRoles 同名设置覆盖。"
-        },
-        "AndreaNovelHelper.roles.display.useRoleSvgIfPresent": {
-          "anhName": "使用角色SVG图标",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "如果角色对象包含 svg 字段，是否优先使用该 svg 作为角色图标（默认: false）。支持 data URI 或相对/绝对路径。"
-        },
-        "AndreaNovelHelper.docRoles.details.showColorOnValue": {
-          "anhName": "显示颜色预览",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "在当前文章角色视图中，在值行上显示颜色预览色块（默认: true）。"
-        },
-        "AndreaNovelHelper.docRoles.display.useRoleSvgIfPresent": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "使用角色SVG图标",
-          "markdownDescription": "在当前文章角色视图中，如果角色对象包含 svg 字段，是否优先使用该 svg 作为角色图标（默认: false）。"
-        },
-        "AndreaNovelHelper.docRoles.display.colorizeRoleName": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "角色名称着色",
-          "markdownDescription": "用角色颜色在名称旁显示色块标记（仅影响名称前的图标，不改变文本颜色）。"
-        },
-        "AndreaNovelHelper.docRoles.inheritExpandedFromPrevious": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "继承展开状态",
-          "markdownDescription": "当切换到一个尚无展开记录的文档时，继承上一个文档的展开集合（仅对两者共有的节点生效）。"
-        },
-        "AndreaNovelHelper.allRoles.display.colorizeRoleName": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "角色名称着色",
-          "markdownDescription": "用角色颜色在名称旁显示色块标记（全部角色视图；当未与 docRoles 同步时生效）。"
-        },
-        "AndreaNovelHelper.package.roleNodes.display.useRoleSvgIfPresent": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "包管理器角色节点使用角色SVG图标",
-          "markdownDescription": "在包管理器的文件子角色节点中，如果角色对象包含 svg 字段，是否优先使用该 svg 作为图标。"
-        },
-        "AndreaNovelHelper.package.roleNodes.display.colorizeRoleName": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "包管理器角色节点名称着色",
-          "markdownDescription": "在包管理器的文件子角色节点中，用角色颜色在名称旁显示色块标记。"
-        },
-        "andrea.typeset.statusBar.compact": {
-          "type": "boolean",
-          "default": false,
-          "scope": "window",
-          "anhName": "状态栏显示模式",
-          "markdownDescription": "版式状态栏显示为**简略模式**（仅显示“版式”）。关闭则显示详细信息（缩进、段距、去尾空格、括号补齐、跳出、切段等）。"
-        },
-        "andrea.typeset.statusBar.alwaysShow": {
-          "anhName": "始终显示版式工具条",
-          "type": "boolean",
-          "default": true,
-          "scope": "window",
-          "markdownDescription": "始终显示版式工具条，无论当前是否为支持的文档类型。"
-        },
-        "andrea.typeset.pairs": {
-          "anhName": "自动补齐括号对",
-          "type": [
-            "array",
-            "string"
-          ],
-          "default": [
-            "()",
-            "[]",
-            "{}",
-            "“”",
-            "‘’",
-            "「」",
-            "『』",
-            "《》",
-            "〈〉",
-            "（）"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.typeset.pairs.markdownDescription%"
-        },
-        "andrea.typeset.enableAutoPairs": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "智慧补齐括号",
-          "description": "%config.typeset.enableAutoPairs.description%"
-        },
-        "andrea.typeset.enableChineseIMEFix": {
-          "anhName": "修复中文输入法",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.typeset.enableChineseIMEFix.description%"
-        },
-        "andrea.typeset.chineseIMEDelay": {
-          "anhName": "中文输入法延迟",
-          "type": "number",
-          "default": 50,
-          "minimum": 0,
-          "maximum": 500,
-          "markdownDescription": "%config.typeset.chineseIMEDelay.description%"
-        },
-        "andrea.typeset.enableSmartEnter": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "智慧切段（Enter）",
-          "description": "%config.typeset.enableSmartEnter.description%"
-        },
-        "andrea.typeset.enableSmartExit": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "智慧跳出括号/引号",
-          "description": "%config.typeset.enableSmartExit.description%"
-        },
-        "andrea.typeset.indentFirstTwoSpaces": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "段首缩进",
-          "description": "%config.typeset.indentFirstTwoSpaces.description%"
-        },
-        "andrea.typeset.blankLinesBetweenParas": {
-          "type": "integer",
-          "default": 1,
-          "minimum": 0,
-          "maximum": 6,
-          "anhName": "段间空行数",
-          "description": "%config.typeset.blankLinesBetweenParas.description%"
-        },
-        "andrea.typeset.addBlanks.sentenceEnders": {
-          "anhName": "句末标点",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "。",
-            "！",
-            "？",
-            "…",
-            "；",
-            "：",
-            "!",
-            "?",
-            ";",
-            ":",
-            "."
-          ],
-          "description": "%config.typeset.addBlanks.sentenceEnders.description%"
-        },
-        "andrea.typeset.addBlanks.trailingClosers": {
-          "anhName": "后置括号",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "'",
-            "\"",
-            "\\'",
-            "\"",
-            "」",
-            "』",
-            "》",
-            "）",
-            "】",
-            "〉",
-            "〕",
-            "〗",
-            "〙",
-            "〛",
-            "〞",
-            "＂",
-            "＇",
-            "｝",
-            "］"
-          ],
-          "description": "%config.typeset.addBlanks.trailingClosers.description%"
-        },
-        "andrea.typeset.addBlanks.leadingOpeners": {
-          "anhName": "前导括号列表",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "“",
-            "\"",
-            "『",
-            "「",
-            "（",
-            "(",
-            "《",
-            "〈",
-            "【",
-            "["
-          ],
-          "description": "%config.typeset.addBlanks.leadingOpeners.description%"
-        },
-        "andrea.typeset.trimTrailingSpaces": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "去尾空格",
-          "description": "%config.typeset.trimTrailingSpaces.description%"
-        },
-        "AndreaNovelHelper.enableWordSegmentFilter": {
-          "anhName": "启用词汇过滤",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.roles.enableWordSegmentFilter.description%"
-        },
-        "AndreaNovelHelper.wordSegment.autoFilterMaxLength": {
-          "anhName": "自动过滤最大长度",
-          "type": "integer",
-          "default": 1,
-          "minimum": 1,
-          "maximum": 6,
-          "description": "%config.roles.wordSegment.autoFilterMaxLength.description%"
-        },
-        "AndreaNovelHelper.rolesFile": {
-          "anhName": "角色文件路径",
-          "type": "string",
-          "default": "novel-helper/character-gallery.json5",
-          "description": "%config.rolesFile.description%"
-        },
-        "andrea.roleJson5.openWithRoleManager": {
-          "anhName": "使用角色管理器打开",
-          "type": "boolean",
-          "default": true,
-          "description": "是否默认使用角色卡管理器打开 JSON5 角色文件"
-        },
-        "AndreaNovelHelper.roleEditor.localizedKeyLabels": {
-          "anhName": "角色编辑器字段显示名本地化",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "%config.roleEditor.localizedKeyLabels.markdownDescription%"
-        },
-        "AndreaNovelHelper.sensitiveWordsFile": {
-          "anhName": "敏感词文件路径",
-          "type": "string",
-          "default": "novel-helper/sensitive-words.json5",
-          "description": "%config.sensitiveWordsFile.description%"
-        },
-        "AndreaNovelHelper.vocabularyFile": {
-          "anhName": "词汇文件路径",
-          "type": "string",
-          "default": "novel-helper/vocabulary.json5",
-          "description": "%config.vocabularyFile.description%"
-        },
-        "AndreaNovelHelper.regexPatternsFile": {
-          "anhName": "正则模式文件路径",
-          "type": "string",
-          "default": "novel-helper/regex-patterns.json5",
-          "description": "%config.regexPatternsFile.description%"
-        },
-        "AndreaNovelHelper.outlinePath": {
-          "anhName": "大纲路径",
-          "type": "string",
-          "default": "novel-helper/outline",
-          "description": "%config.outlinePath.description%"
-        },
-        "AndreaNovelHelper.rolePriority": {
-          "anhName": "角色合并优先级策略",
-          "type": "object",
-          "default": {
-            "strategy": "loadOrder",
-            "enableFileNamePriority": false,
-            "enableFileTypePriority": false,
-            "enableLocationPriority": false,
-            "fileNamePriority": {
-              "prefixes": {
-                "__": 1000,
-                "!!": 2000,
-                "!!!": 3000,
-                "override_": 1500,
-                "config_": 500
-              },
-              "naturalSort": true
-            },
-            "fileTypePriority": {
-              ".md": 1,
-              ".json5": 2,
-              ".ojson5": 3,
-              ".txt": 0
-            },
-            "locationPriority": {
-              "external": 100,
-              "internal": 0
-            },
-            "defaultPriority": 0
-          },
-          "properties": {
-            "strategy": {
-              "type": "string",
-              "enum": [
-                "loadOrder",
-                "custom"
-              ],
-              "default": "loadOrder",
-              "description": "%config.rolePriority.strategy.description%"
-            },
-            "enableFileNamePriority": {
-              "type": "boolean",
-              "default": false,
-              "description": "%config.rolePriority.enableFileNamePriority.description%"
-            },
-            "enableFileTypePriority": {
-              "type": "boolean",
-              "default": false,
-              "description": "%config.rolePriority.enableFileTypePriority.description%"
-            },
-            "enableLocationPriority": {
-              "type": "boolean",
-              "default": false,
-              "description": "%config.rolePriority.enableLocationPriority.description%"
-            },
-            "fileNamePriority": {
-              "type": "object",
-              "description": "%config.rolePriority.fileNamePriority.description%",
-              "properties": {
-                "prefixes": {
-                  "type": "object",
-                  "description": "%config.rolePriority.fileNamePriority.prefixes.description%"
-                },
-                "naturalSort": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.rolePriority.fileNamePriority.naturalSort.description%"
-                }
-              }
-            },
-            "fileTypePriority": {
-              "type": "object",
-              "description": "%config.rolePriority.fileTypePriority.description%"
-            },
-            "locationPriority": {
-              "type": "object",
-              "properties": {
-                "external": {
-                  "type": "number",
-                  "default": 100,
-                  "description": "%config.rolePriority.locationPriority.external.description%"
-                },
-                "internal": {
-                  "type": "number",
-                  "default": 0,
-                  "description": "%config.rolePriority.locationPriority.internal.description%"
-                }
-              },
-              "description": "%config.rolePriority.locationPriority.description%"
-            },
-            "defaultPriority": {
-              "type": "number",
-              "default": 0,
-              "description": "%config.rolePriority.defaultPriority.description%"
-            }
-          },
-          "description": "%config.rolePriority.description%"
-        },
-        "AndreaNovelHelper.outline.lazyMode": {
-          "anhName": "懒加载模式",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.outline.lazyMode.description%"
-        },
-        "AndreaNovelHelper.minChars": {
-          "anhName": "最少字符数",
-          "type": "number",
-          "default": 1,
-          "minimum": 1,
-          "description": "%config.minChars.description%"
-        },
-        "AndreaNovelHelper.supportedFileTypes": {
-          "anhName": "支持的文件类型",
-          "type": "array",
-          "default": [
-            "markdown",
-            "plaintext",
-            "json5",
-            "csv",
-            "ojson",
-            "ojson5",
-            "rjson",
-            "rjson5",
-            "tjson5"
-          ],
-          "description": "%config.supportedFileTypes.description%"
-        },
-        "AndreaNovelHelper.customCharacterFileKeywords": {
-          "anhName": "自定义角色文件关键词",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.customCharacterFileKeywords.description%"
-        },
-        "AndreaNovelHelper.customSensitiveWordsFileKeywords": {
-          "anhName": "自定义敏感词文件关键词",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.customSensitiveWordsFileKeywords.description%"
-        },
-        "AndreaNovelHelper.customVocabularyFileKeywords": {
-          "anhName": "自定义词汇文件关键词",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.customVocabularyFileKeywords.description%"
-        },
-        "AndreaNovelHelper.customRegexFileKeywords": {
-          "anhName": "自定义正则文件关键词",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.customRegexFileKeywords.description%"
-        },
-        "AndreaNovelHelper.workspaceDisabled": {
-          "anhName": "禁用工作区",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.workspaceDisabled.description%"
-        },
-        "AndreaNovelHelper.hello.enabled": {
-          "anhName": "启用 ANH Hello 首页",
-          "type": "boolean",
-          "default": true,
-          "description": "启动时显示 Andrea Novel Helper 的独立新手首页，也可通过命令面板手动打开。"
-        },
-        "AndreaNovelHelper.hello.forceVsCodeManagedDisabling": {
-          "anhName": "Hello 模式只跟随 VS Code 扩展开关",
-          "type": "boolean",
-          "default": true,
-          "description": "启用 Hello 首页时，在运行时绕过 ANH 自己的工作区禁用判断，改为只跟随 VS Code 扩展管理里的启用/禁用状态；不会改写 AndreaNovelHelper.useVsCodeManagedDisabling 原设置。"
-        },
-        "AndreaNovelHelper.useVsCodeManagedDisabling": {
-          "anhName": "完全使用 VSCode 托管的禁用系统",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.useVsCodeManagedDisabling.description%",
-          "markdownDescription": "开启后扩展不再读取 Andrea Novel Helper 自己的“禁用/工作区禁用”配置，只按 VS Code 扩展管理里的启用/禁用状态决定是否运行。适合希望完全通过 VS Code 内置禁用系统控制插件生效范围的场景。"
-        },
-        "AndreaNovelHelper.markdownToolbarEnabled": {
-          "anhName": "启用Markdown工具栏",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.markdownToolbarEnabled.description%"
-        },
-        "AndreaNovelHelper.markdownToolbarHeight": {
-          "anhName": "工具栏高度",
-          "type": "number",
-          "default": 28,
-          "minimum": 20,
-          "maximum": 50,
-          "description": "%config.markdownToolbarHeight.description%"
-        },
-        "AndreaNovelHelper.timeStats.enabledLanguages": {
-          "anhName": "统计启用语言",
-          "type": "array",
-          "default": [
-            "markdown",
-            "plaintext"
-          ],
-          "description": "%config.timeStats.enabledLanguages.description%"
-        },
-        "AndreaNovelHelper.hugeFile.thresholdBytes": {
-          "anhName": "超大文件阈值",
-          "type": "number",
-          "default": 51200,
-          "minimum": 1024,
-          "maximum": 10485760,
-          "description": "%config.hugeFile.thresholdBytes.description%"
-        },
-        "AndreaNovelHelper.hugeFile.suppressWarning": {
-          "anhName": "抑制警告",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.hugeFile.suppressWarning.description%"
-        },
-        "AndreaNovelHelper.timeStats.idleThresholdMs": {
-          "anhName": "闲置阈值",
-          "type": "number",
-          "default": 30000,
-          "minimum": 5000,
-          "maximum": 300000,
-          "description": "%config.timeStats.idleThresholdMs.description%"
-        },
-        "AndreaNovelHelper.timeStats.bucketSizeMs": {
-          "anhName": "统计时间桶",
-          "type": "number",
-          "default": 60000,
-          "minimum": 10000,
-          "maximum": 600000,
-          "description": "%config.timeStats.bucketSizeMs.description%"
-        },
-        "AndreaNovelHelper.timeStats.imeDebounceMs": {
-          "anhName": "输入法防抖",
-          "type": "number",
-          "default": 350,
-          "minimum": 100,
-          "maximum": 2000,
-          "description": "%config.timeStats.imeDebounceMs.description%"
-        },
-        "AndreaNovelHelper.timeStats.respectWcignore": {
-          "anhName": "遵循忽略文件",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.timeStats.respectWcignore.description%"
-        },
-        "AndreaNovelHelper.timeStats.exitIdleOn": {
-          "anhName": "退出闲置触发",
-          "type": "string",
-          "default": "text-change",
-          "enum": [
-            "text-change",
-            "window-focus",
-            "editor-change"
-          ],
-          "enumDescriptions": [
-            "%config.timeStats.exitIdleOn.textChange%",
-            "%config.timeStats.exitIdleOn.windowFocus%",
-            "%config.timeStats.exitIdleOn.editorChange%"
-          ],
-          "description": "%config.timeStats.exitIdleOn.description%"
-        },
-        "AndreaNovelHelper.timeStats.largeFile.thresholdBytes": {
-          "anhName": "大文件阈值",
-          "type": "number",
-          "default": 65536,
-          "minimum": 4096,
-          "description": "%config.timeStats.largeFile.thresholdBytes.description%"
-        },
-        "AndreaNovelHelper.timeStats.largeFile.approximate": {
-          "anhName": "大文件近似统计",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.timeStats.largeFile.approximate.description%"
-        },
-        "AndreaNovelHelper.timeStats.largeFile.accurateEveryChanges": {
-          "anhName": "精确统计变更次数",
-          "type": "number",
-          "default": 80,
-          "minimum": 5,
-          "description": "%config.timeStats.largeFile.accurateEveryChanges.description%"
-        },
-        "AndreaNovelHelper.timeStats.largeFile.accurateEveryMs": {
-          "anhName": "精确统计时间间隔",
-          "type": "number",
-          "default": 60000,
-          "minimum": 5000,
-          "description": "%config.timeStats.largeFile.accurateEveryMs.description%"
-        },
-        "AndreaNovelHelper.timeStats.debug": {
-          "anhName": "调试模式",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.timeStats.debug.description%"
-        },
-        "AndreaNovelHelper.timeStats.milestone.enabled": {
-          "anhName": "里程碑启用",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.timeStats.milestone.enabled.description%"
-        },
-        "AndreaNovelHelper.timeStats.milestone.targets": {
-          "anhName": "里程碑目标",
-          "type": "array",
-          "default": [
-            1000,
-            2000,
-            5000,
-            10000,
-            20000,
-            50000,
-            100000
-          ],
-          "items": {
-            "type": "number",
-            "minimum": 1
-          },
-          "description": "%config.timeStats.milestone.targets.description%"
-        },
-        "AndreaNovelHelper.timeStats.milestone.notificationType": {
-          "anhName": "里程碑通知类型",
-          "type": "string",
-          "default": "information",
-          "enum": [
-            "information",
-            "modal"
-          ],
-          "enumDescriptions": [
-            "%config.timeStats.milestone.notificationType.information%",
-            "%config.timeStats.milestone.notificationType.modal%"
-          ],
-          "description": "%config.timeStats.milestone.notificationType.description%"
-        },
-        "AndreaNovelHelper.timeStats.typoDelay.enabled": {
-          "anhName": "错别字延迟启用",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用变更时间窗口机制：在连续编辑期间延迟发送错别字请求，窗口结束后统一触发。"
-        },
-        "AndreaNovelHelper.timeStats.typoDelay.windowMs": {
-          "anhName": "错别字延迟窗口",
-          "type": "number",
-          "default": 5000,
-          "minimum": 100,
-          "maximum": 1000000,
-          "markdownDescription": "变更时间窗口时长（毫秒）。窗口内的连续变更将合并为一次错别字请求。"
-        },
-        "AndreaNovelHelper.wordCount.largeFileThreshold": {
-          "anhName": "大文件阈值",
-          "type": "number",
-          "default": 51200,
-          "minimum": 1024,
-          "description": "%config.wordCount.largeFileThreshold.description%"
-        },
-        "AndreaNovelHelper.wordCount.largeFileAvgBytesPerChar": {
-          "anhName": "大文件平均字节数",
-          "type": "number",
-          "default": 3,
-          "minimum": 0.5,
-          "maximum": 10,
-          "description": "%config.wordCount.largeFileAvgBytesPerChar.description%"
-        },
-        "AndreaNovelHelper.timeStats.persistReadOnlySessions": {
-          "anhName": "只读会话持久化",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.timeStats.persistReadOnlySessions.description%"
-        },
-        "AndreaNovelHelper.timeStats.statusBar.alignment": {
-          "anhName": "状态栏对齐",
-          "type": "string",
-          "default": "left",
-          "enum": [
-            "left",
-            "right"
-          ],
-          "enumDescriptions": [
-            "%config.timeStats.statusBar.alignment.left%",
-            "%config.timeStats.statusBar.alignment.right%"
-          ],
-          "description": "%config.timeStats.statusBar.alignment.description%"
-        },
-        "AndreaNovelHelper.timeStats.statusBar.priority": {
-          "anhName": "状态栏优先级",
-          "type": "number",
-          "default": 1,
-          "minimum": -1000,
-          "maximum": 1000,
-          "description": "%config.timeStats.statusBar.priority.description%"
-        },
-        "AndreaNovelHelper.timeStats.includePaste": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "粘贴计入统计",
-          "markdownDescription": "是否将复制粘贴文本统一计入统计：包括速度（字/分钟、字/小时）与新增/净增字符。默认关闭，仅统计实际书写增量。"
-        },
-        "AndreaNovelHelper.timeStats.includePasteInSpeed": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "粘贴计入速度",
-          "markdownDescription": "是否将复制粘贴的文本计入速度统计（字/分钟、字/小时）。默认不计入，仅统计实际书写增量。"
-        },
-        "AndreaNovelHelper.timeStats.includePasteInAddedCounters": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "粘贴计入新增",
-          "markdownDescription": "是否将复制粘贴的文本计入“新增/净增”字符统计。默认计入；关闭后仅统计非粘贴产生的新增字符。"
-        },
-        "AndreaNovelHelper.timeStats.pasteThresholdChars": {
-          "type": "number",
-          "default": 32,
-          "minimum": 1,
-          "maximum": 100000,
-          "anhName": "粘贴判定阈值",
-          "markdownDescription": "粘贴判定阈值（字符数）。当一次变更新增字符数 ≥ 该值或包含换行时，视为粘贴。"
-        },
-        "AndreaNovelHelper.fileTracker.respectWcignore": {
-          "anhName": "遵循忽略文件",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.fileTracker.respectWcignore.description%"
-        },
-        "AndreaNovelHelper.fileTracker.respectGitignore": {
-          "anhName": "遵循 Git 忽略",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.fileTracker.respectGitignore.description%"
-        },
-        "AndreaNovelHelper.fileTracker.trustCallerFilters": {
-          "anhName": "信任调用方过滤器",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.fileTracker.trustCallerFilters.description%"
-        },
-        "AndreaNovelHelper.fileTracker.writeLegacySnapshot": {
-          "anhName": "写入旧版快照",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.fileTracker.writeLegacySnapshot.description%"
-        },
-        "AndreaNovelHelper.fileTracker.enableVerboseLogging": {
-          "anhName": "启用详细日志",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.fileTracker.enableVerboseLogging.description%"
-        },
-        "AndreaNovelHelper.wordCount.order.showIndexInLabel": {
-          "anhName": "显示索引",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.wordCount.order.showIndexInLabel.description%"
-        },
-        "AndreaNovelHelper.wordCount.order.step": {
-          "anhName": "索引步长",
-          "type": "number",
-          "default": 10,
-          "minimum": 1,
-          "description": "%config.wordCount.order.step.description%"
-        },
-        "AndreaNovelHelper.wordCount.order.padWidth": {
-          "anhName": "索引宽度",
-          "type": "number",
-          "default": 3,
-          "minimum": 0,
-          "description": "%config.wordCount.order.padWidth.description%"
-        },
-        "AndreaNovelHelper.wordCount.order.autoResequence": {
-          "anhName": "自动重排序",
-          "type": "boolean",
-          "default": true,
-          "description": "%config.wordCount.order.autoResequence.description%"
-        },
-        "AndreaNovelHelper.wordCount.displayFormat": {
-          "anhName": "显示格式",
-          "type": "string",
-          "default": "wan",
-          "enum": [
-            "raw",
-            "wan",
-            "k",
-            "qian"
-          ],
-          "enumDescriptions": [
-            "%config.wordCount.displayFormat.raw%",
-            "%config.wordCount.displayFormat.wan%",
-            "%config.wordCount.displayFormat.k%",
-            "%config.wordCount.displayFormat.qian%"
-          ],
-          "description": "%config.wordCount.displayFormat.description%"
-        },
-        "AndreaNovelHelper.wordCount.debug": {
-          "anhName": "调试模式",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.wordCount.debug.description%"
-        },
-        "AndreaNovelHelper.wordCount.respectGitignore": {
-          "anhName": "遵循Git忽略",
-          "type": "boolean",
-          "default": true,
-          "description": "写作资源管理器是否遵循 .gitignore（默认开启）。关闭后仅依据 .wcignore（若下项开启）或完全不依据忽略文件。"
-        },
-        "AndreaNovelHelper.wordCount.respectWcignore": {
-          "anhName": "遵循字数忽略",
-          "type": "boolean",
-          "default": true,
-          "description": "写作资源管理器是否遵循 .wcignore（默认开启）。关闭后将不从 .wcignore 读取忽略规则。"
-        },
-        "AndreaNovelHelper.wordCount.primaryUnit": {
-          "type": "string",
-          "default": "excludePunct",
-          "enum": [
-            "excludePunct",
-            "includePunct",
-            "nonWSNoPunct"
-          ],
-          "enumDescriptions": [
-            "词计（CJK 字符 + 英文单词）",
-            "含标点（非空白字符）",
-            "不含标点（非空白且排除标点）"
-          ],
-          "anhName": "字数单位",
-          "markdownDescription": "字数统计首要显示单位：\n- **excludePunct**：词计（`CJK 字符 + 英文单词`）\n- **includePunct**：含标点（`非空白字符`）\n- **nonWSNoPunct**：不含标点（`非空白且排除标点`）"
-        },
-        "AndreaNovelHelper.wordCount.statusBar.speedUnit": {
-          "type": "string",
-          "default": "cpm",
-          "enum": [
-            "cpm",
-            "cph"
-          ],
-          "enumDescriptions": [
-            "字/分钟",
-            "字/小时"
-          ],
-          "anhName": "速度单位",
-          "markdownDescription": "字数统计状态栏速度单位：\n- **cpm**：字/分钟\n- **cph**：字/小时"
-        },
-        "AndreaNovelHelper.wordCount.statusBar.mode": {
-          "type": "string",
-          "default": "detailed",
-          "enum": [
-            "detailed",
-            "semi",
-            "compact"
-          ],
-          "enumDescriptions": [
-            "详细：显示用时、字数与速度",
-            "半精简：显示字数与当前速度",
-            "精简：仅显示总字数"
-          ],
-          "anhName": "状态栏显示模式",
-          "markdownDescription": "字数统计状态栏显示模式：\n- **detailed**：显示用时、字数与速度\n- **semi**：显示字数与当前速度\n- **compact**：仅显示总字数"
-        },
-        "AndreaNovelHelper.wordCount.statusBar.compact": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "状态栏精简模式",
-          "markdownDescription": "字数统计状态栏精简模式：仅显示总计字数；隐藏时间与速度等附加信息。"
-        },
-        "AndreaNovelHelper.wordCount.maxWorkers": {
-          "anhName": "最大工作线程",
-          "type": "number",
-          "default": 0,
-          "minimum": 0,
-          "maximum": 128,
-          "description": "%config.wordCount.maxWorkers.description%"
-        },
-        "AndreaNovelHelper.wordCount.maxWorkersUpperLimit": {
-          "anhName": "最大工作线程上限",
-          "type": "number",
-          "default": 8,
-          "minimum": 1,
-          "maximum": 128,
-          "description": "%config.wordCount.maxWorkersUpperLimit.description%"
-        },
-        "AndreaNovelHelper.wordCount.skipStartupStatCheck": {
-          "anhName": "跳过启动校验",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "⚠️ 危险选项：启用后，字数统计视图在**冷启动扫描文件时将跳过对已有缓存文件的 fs.stat 校验**，直接信任快照 / 文件追踪数据库 / 内存中的字数统计。这样可以显著减少启动时间，但**无法在启动阶段发现第三方软件或外部工具对文件内容的篡改**，也无法保证缓存与文件系统 100% 一致。仅在你确信本地文本文件几乎不会在 VS Code 之外被修改时使用。"
-        },
-        "AndreaNovelHelper.wordCount.parallelStatCheck": {
-          "anhName": "并行校验",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "启用并行批量 fs.stat 校验。开启后，在冷启动 cache-check 阶段将对所有已缓存文件并行执行 fs.stat（而非逐个串行），显著减少校验耗时。适用于文件数量较多且磁盘/文件系统 I/O 性能较好的场景。注意：当 `skipStartupStatCheck` 开启时，此选项无效。"
-        },
-        "AndreaNovelHelper.debug.completionLog": {
-          "anhName": "调试日志",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.debug.completionLog.description%"
-        },
-        "AndreaNovelHelper.debug.roleFileDetection": {
-          "anhName": "角色文件识别调试",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.debug.roleFileDetection.description%"
-        },
-        "AndreaNovelHelper.debug.smartRoleAdder": {
-          "anhName": "角色合并调试",
-          "type": "boolean",
-          "default": false,
-          "description": "%config.debug.smartRoleAdder.description%"
-        },
-        "AndreaNovelHelper.completion.triggerMode": {
-          "anhName": "补全触发模式",
-          "type": "string",
-          "enum": [
-            "loose",
-            "startsWith",
-            "symbolLoose",
-            "symbolStartsWith"
-          ],
-          "default": "loose",
-          "enumDescriptions": [
-            "完全触发（名称包含当前前缀即可触发）",
-            "仅首字（仅当名称/别名以当前前缀开头时触发）",
-            "符号+完全触发（仅当前缀前有指定符号且名称包含前缀时触发）",
-            "符号+仅首字（仅当前缀前有指定符号且名称/别名以当前前缀开头时触发）"
-          ],
-          "markdownDescription": "%config.completion.triggerMode.description%"
-        },
-        "AndreaNovelHelper.completion.symbolPrefixes": {
-          "anhName": "补全符号前缀",
-          "type": "array",
-          "default": [
-            "@"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.completion.symbolPrefixes.description%"
-        },
-        "AndreaNovelHelper.lookupKeys.treatPinyinAsAlias": {
-          "anhName": "拼音查询键按别名展示",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.lookupKeys.treatPinyinAsAlias.description%"
-        },
-        "AndreaNovelHelper.lookupKeys.autoGeneratePinyin": {
-          "anhName": "自动生成拼音查询键",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.lookupKeys.autoGeneratePinyin.description%"
-        },
-        "AndreaNovelHelper.lookupKeys.treatRomanizedAsAlias": {
-          "anhName": "罗马字查询键按别名展示",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.lookupKeys.treatRomanizedAsAlias.description%"
-        },
-        "AndreaNovelHelper.lookupKeys.autoGenerateRomanized": {
-          "anhName": "自动生成罗马字查询键",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.lookupKeys.autoGenerateRomanized.description%"
-        },
-        "AndreaNovelHelper.lookupKeys.useLlmRomanization": {
-          "anhName": "罗马字查询键使用 LLM",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%config.lookupKeys.useLlmRomanization.description%"
-        },
-        "AndreaNovelHelper.defaultRoleLookupKeys": {
-          "anhName": "默认角色索引键",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.defaultRoleLookupKeys.description%"
-        },
-        "AndreaNovelHelper.extendedLookupKeyPrefixes": {
-          "anhName": "扩展索引键前缀",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "%config.extendedLookupKeyPrefixes.description%"
-        },
-        "AndreaNovelHelper.completion.segmenterType": {
-          "anhName": "分词器类型",
-          "type": "string",
-          "enum": [
-            "auto",
-            "intl",
-            "jieba"
-          ],
-          "default": "auto",
-          "markdownDescription": "自动补全分词器类型：\n- **auto**：智能选择，中文内容较多时自动使用jieba，否则使用Intl.Segmenter\n- **intl**：强制使用浏览器内置的Intl.Segmenter\n- **jieba**：强制使用jieba中文分词器\n\njieba分词器对中文分词更准确，能提供更好的中文输入补全体验。"
-        },
-        "AndreaNovelHelper.decorations.cacheSize": {
-          "anhName": "装饰缓存大小",
-          "type": "number",
-          "default": 5,
-          "minimum": 0,
-          "maximum": 20,
-          "description": "%config.decorations.cacheSize.description%"
-        },
-        "AndreaNovelHelper.roles.details.alwaysExpandable": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "总是可展开",
-          "markdownDescription": "角色属性详情是否总是可展开；开启后所有属性行都能展开为多行显示。"
-        },
-        "AndreaNovelHelper.roles.details.enableWrapping": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "启用角色详情折行",
-          "markdownDescription": "是否在角色属性详情展开后按列宽进行软折行。关闭后长文本保持单行显示；路径、URI、UUID、正则、SVG/图标等字段始终不会按列宽硬折行。"
-        },
-        "AndreaNovelHelper.roles.details.wrapColumn": {
-          "type": "number",
-          "default": 20,
-          "minimum": 5,
-          "maximum": 200,
-          "anhName": "折行宽度",
-          "markdownDescription": "角色属性详情的软折行宽度（列数），用于多行显示的每行最大字符数。"
-        },
-        "AndreaNovelHelper.roles.details.enableRoleExpansion": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "启用角色展开",
-          "markdownDescription": "是否允许角色节点可展开以查看属性详情；关闭后角色节点将不再可展开。"
-        },
-        "AndreaNovelHelper.package.roleNodes.details.showColorOnValue": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "包管理器角色详情显示颜色预览",
-          "markdownDescription": "在包管理器的文件子角色节点详情中，是否在颜色字段值行显示颜色预览色块。"
-        },
-        "AndreaNovelHelper.package.roleNodes.details.alwaysExpandable": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "包管理器角色详情总是可展开",
-          "markdownDescription": "包管理器的文件子角色节点中，角色属性详情是否总是可展开。"
-        },
-        "AndreaNovelHelper.package.roleNodes.details.enableWrapping": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "包管理器角色详情启用折行",
-          "markdownDescription": "是否在包管理器的角色详情展开后按列宽进行软折行。关闭后长文本保持单行显示；路径、URI、UUID、正则、SVG/图标等字段始终不会按列宽硬折行。"
-        },
-        "AndreaNovelHelper.package.roleNodes.details.wrapColumn": {
-          "type": "number",
-          "default": 20,
-          "minimum": 5,
-          "maximum": 200,
-          "anhName": "包管理器角色详情折行宽度",
-          "markdownDescription": "包管理器的文件子角色节点详情在多行显示时的软折行宽度。"
-        },
-        "AndreaNovelHelper.package.roleNodes.details.enableRoleExpansion": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "包管理器启用角色展开",
-          "markdownDescription": "包管理器的文件子角色节点是否允许展开查看属性详情。"
-        },
-        "AndreaNovelHelper.typo.service.baseUrl": {
-          "anhName": "错别字服务地址",
-          "type": "string",
-          "default": "http://127.0.0.1:8001",
-          "markdownDescription": "错别字服务 API 基地址，例如 http://127.0.0.1:8001"
-        },
-        "AndreaNovelHelper.typo.enabled": {
-          "anhName": "启用错别字检查",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用错别字识别与诊断（关闭后不再调用服务、扫描或标注）。"
-        },
-        "AndreaNovelHelper.typo.mode": {
-          "anhName": "错别字检查模式",
-          "type": "string",
-          "enum": [
-            "macro",
-            "llm"
-          ],
-          "default": "macro",
-          "markdownDescription": "错别字识别模式：macro 使用 /correct（规则）；llm 使用 /correct/llm（大语言模型）。\n\n⚠️ **数据安全提醒**：使用 llm 模式时，您的文档内容将发送至第三方服务或本地大模型进行处理。请确保您信任所使用的服务提供商，并自行承担数据安全责任。"
-        },
-        "AndreaNovelHelper.typo.autoIdentifyOnOpen": {
-          "anhName": "打开时自动检查",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "打开文档时是否自动进行错别字识别。关闭后需要手动点击重新识别按钮。"
-        },
-        "AndreaNovelHelper.typo.autoScanOnChange": {
-          "anhName": "变更时自动扫描",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "在编辑内容发生变更时是否自动触发错别字扫描。关闭后仅保留手动扫描模式（通过命令或快速设置触发）。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.enabled": {
-          "anhName": "启用客户端大模型",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "使用本地客户端直连大模型进行错别字识别（实验功能，优先于服务端）。\n\n⚠️ **数据安全提醒**：启用此功能后，您的文档内容将通过配置的 API 发送至第三方大模型服务。请确保您信任所使用的服务提供商，并自行承担数据安全和隐私保护责任。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.apiBase": {
-          "anhName": "API基地址",
-          "type": "string",
-          "default": "https://api.deepseek.com/v1",
-          "markdownDescription": "Chat Completions 兼容 API Base（如 https://api.openai.com/v1 或 DeepSeek）。\n\n⚠️ **数据安全提醒**：配置第三方 API 地址时，请确保您信任该服务提供商。您的文档内容将通过此 API 发送进行处理，请自行评估和承担数据安全风险。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.apiKey": {
-          "anhName": "API密钥",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "客户端直连大模型 API Key（请注意安全）。\n\n⚠️ **数据安全提醒**：API Key 将用于访问第三方服务。请妥善保管您的密钥，避免在共享配置或代码中泄露，并定期更换以确保安全。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.model": {
-          "anhName": "模型名称",
-          "type": "string",
-          "default": "deepseek-v3",
-          "markdownDescription": "客户端直连模型名称。\n\n⚠️ **数据安全提醒**：不同模型的服务商可能有不同的数据处理政策。请在使用前查看并了解相应模型提供商的数据使用条款。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.temperature": {
-          "anhName": "温度参数",
-          "type": "number",
-          "default": 0,
-          "minimum": 0,
-          "maximum": 2,
-          "markdownDescription": "客户端直连模型的 temperature。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.enableThinking": {
-          "anhName": "启用思考模式",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用深度思考模型的思考过程（如 GLM-4.6、GLM-4.5、GLM-4.5-air、DeepSeek-R1、Qwen-R 等支持推理的模型）。\n\n🔧 **配置方式**：需要配合 `thinkingProvider` 配置项来指定参数格式。\n\n📋 **支持的供应商预设**：\n- `auto`：自动检测（默认）\n- `glm`：智谱 GLM 系列\n- `deepseek`：DeepSeek 系列\n- `qwen`：通义千问系列\n- `custom`：自定义配置\n\n⚠️ **注意**：思考过程仅在支持相应格式的模型上有效，请根据模型类型选择合适的预设。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.thinkingProvider": {
-          "anhName": "思考提供商",
-          "type": "string",
-          "default": "auto",
-          "enum": [
-            "auto",
-            "glm",
-            "deepseek",
-            "qwen",
-            "custom"
-          ],
-          "markdownDescription": "选择思考过程的参数格式预设。\n\n📋 **预设说明**：\n- `auto`：根据模型名称自动选择合适的参数格式\n- `glm`：智谱 GLM 格式 - `\"thinking\": {\"type\": \"enabled|disabled\"}`\n- `deepseek`：DeepSeek 格式 - `\"extra_body\": {\"enable_thinking\": true}`\n- `qwen`：通义千问格式 - `\"reasoning_effort\": \"high|medium\"`\n- `custom`：使用自定义配置（需配置 `customThinking*` 选项）\n\n💡 **建议**：不确定时选择 `auto`，系统会根据模型名称自动匹配。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.customThinkingEnabled": {
-          "anhName": "自定义思考启用",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用自定义 thinking 字段配置。仅当 `thinkingProvider` 设置为 `custom` 时生效。\n\n⚙️ **配置**：启用后，可配置自定义的字段名和启用/禁用值。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.customThinkingEnabledValue": {
-          "anhName": "自定义思考启用值",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "自定义 thinking 字段的启用值。当 `enableThinking` 为 true 时使用此值。\n\n📝 **示例**：如果字段为 `thinking`，启用值为 `true`，则请求中包含 `\"thinking\": true`。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.customThinkingDisabledValue": {
-          "anhName": "自定义思考禁用值",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "自定义 thinking 字段的禁用值。当 `enableThinking` 为 false 时使用此值。\n\n📝 **示例**：如果字段为 `thinking`，禁用值为 `false`，则请求中包含 `\"thinking\": false`。"
-        },
-        "AndreaNovelHelper.typo.clientLLM.qwenThinkingMethod": {
-          "anhName": "通义千问思考方法",
-          "type": "string",
-          "enum": [
-            "parameter",
-            "suffix"
-          ],
-          "default": "parameter",
-          "markdownDescription": "通义千问模型的 thinking 控制方法选择。当 `thinkingProvider` 设置为 \"qwen\" 时生效。\n\n- **parameter**（默认）：使用 `extra_body.enable_thinking=False` 参数\n- **suffix**：使用模型名称后缀 `/no_think`\n\n📝 **示例**：\n- parameter 方法：`\"extra_body\": {\"enable_thinking\": false}`\n- suffix 方法：`\"model\": \"qwen2.5-72b-instruct/no_think\"`"
-        },
-        "AndreaNovelHelper.typo.clientLLM.geminiThinkingBudget": {
-          "anhName": "Gemini思考预算",
-          "type": "number",
-          "default": -1,
-          "markdownDescription": "Google Gemini 模型的思考预算配置。当 `thinkingProvider` 设置为 \"gemini\" 时生效。\n\n- **-1**（默认）：动态思考，模型根据任务复杂度自动调整预算\n- **0**：禁用思考功能\n- **正数**：指定具体的思考 token 预算（如 1024）\n\n📝 **模型支持**：\n- **Gemini 2.5 Pro**：动态思考（128-32768），无法禁用\n- **Gemini 2.5 Flash**：动态思考（0-24576），可禁用\n- **Gemini 2.5 Flash-Lite**：无思考（512-24576），可禁用\n\n📝 **示例请求**：\n```json\n{\n  \"extra_body\": {\n    \"thinking_config\": {\n      \"thinking_budget\": 1024,\n      \"include_thoughts\": true\n    }\n  }\n}\n```"
-        },
-        "AndreaNovelHelper.typo.clientLLM.geminiApiFormat": {
-          "anhName": "Gemini API格式",
-          "type": "string",
-          "enum": [
-            "openai",
-            "native"
-          ],
-          "default": "openai",
-          "markdownDescription": "Google Gemini 模型的 API 调用格式。当 `thinkingProvider` 设置为 \"gemini\" 时生效。\n\n- **openai**（默认）：使用 OpenAI 兼容的 API 格式，适用于 OpenAI 兼容的代理服务\n- **native**：使用 Gemini 原生 API 格式，直接调用 Google GenerativeAI API\n\n📝 **OpenAI 兼容格式示例**：\n```json\n{\n  \"model\": \"gemini-2.5-flash\",\n  \"messages\": [...],\n  \"reasoning_effort\": \"low\"\n}\n```\n\n📝 **原生 API 格式示例**：\n```json\n{\n  \"contents\": [\n    {\"parts\": [{\"text\": \"...\"}]}\n  ],\n  \"generationConfig\": {\n    \"thinkingConfig\": {\n      \"thinkingBudget\": 1024\n    }\n  }\n}\n```\n\n⚠️ **注意**：使用原生 API 格式时，API Base URL 需要设置为 `https://generativelanguage.googleapis.com/v1beta`"
-        },
-        "AndreaNovelHelper.externalFolder.ignoredDirectories": {
-          "anhName": "外部文件夹忽略目录",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            ".git",
-            ".vscode",
-            ".idea",
-            "node_modules",
-            "dist",
-            "build",
-            "out",
-            ".DS_Store",
-            "Thumbs.db"
-          ],
-          "markdownDescription": "外部资源目录扫描时忽略的目录列表。扫描器会保留对 `__init__.ojson5` 的兼容识别，同时也会根据标识扩展名与关键字识别目录。\n\n📝 **默认忽略**：\n- 版本控制：`.git`\n- 编辑器配置：`.vscode`, `.idea`\n- 依赖包：`node_modules`\n- 构建输出：`dist`, `build`, `out`\n- 系统文件：`.DS_Store`, `Thumbs.db`\n\n📝 **使用示例**：\n```json\n[\n  \".git\",\n  \".vscode\",\n  \"node_modules\",\n  \"dist\",\n  \"temp\",\n  \"logs\"\n]\n```"
-        },
-        "AndreaNovelHelper.externalFolder.markerKeywords": {
-          "anhName": "外部资源标识关键字",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "character-gallery",
-            "character",
-            "role",
-            "roles",
-            "sensitive-words",
-            "sensitive",
-            "vocabulary",
-            "vocab",
-            "regex-patterns",
-            "regex",
-            "relationship",
-            "relation",
-            "connections",
-            "links",
-            "timeline",
-            "角色",
-            "人物",
-            "敏感词",
-            "词汇",
-            "词庫",
-            "词库",
-            "正则",
-            "正則",
-            "正则表达式",
-            "正則表達式",
-            "关系",
-            "关联",
-            "连接",
-            "联系",
-            "时间线",
-            "時間線"
-          ],
-          "markdownDescription": "外部资源目录识别关键字。若文件名命中这些关键字（并且扩展名在支持集合中），其所在目录会被识别为外部资源目录。\n\n⚠️ 同时保留 legacy 支持：目录内包含 `__init__.ojson5` 也会被识别。\n\n📝 **固定扩展名标识（无需关键字）**：`.ojson5`, `.rjson5`, `.ojson`, `.rjson`, `.tjson5`\n\n📝 **关键字扩展名集合**：`.json5`, `.txt`, `.ojson`, `.rjson`, `.rjson5`, `.ojson5`, `.tjson5`\n\n📝 `.md` 不参与关键字匹配；仅当开启下方“MD库名识别”并命中特定库名规则时，才会识别为外部资源标记文件。"
-        },
-        "AndreaNovelHelper.externalFolder.enableMdLibraryNameMarkers": {
-          "anhName": "MD库名识别",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "是否允许将特定命名规则的 `.md` 文件识别为外部资源标记文件。\n\n开启后，仅以下规则会生效：\n- 精确文件名：`character-gallery.md`、`sensitive-words.md`、`vocabulary.md`\n- 后缀规则：`*_character.md`、`*_sensitive.md`、`*_vocabulary.md`（也支持 `-` 连接）\n\n关闭后，`.md` 文件不会被用于外部资源目录标记识别。"
-        },
-        "AndreaNovelHelper.package.dragDefaultAction": {
-          "anhName": "拖拽默认操作",
-          "type": "string",
-          "enum": [
-            "move",
-            "copy",
-            "ask"
-          ],
-          "enumDescriptions": [
-            "默认移动（剪切）",
-            "默认复制",
-            "每次询问"
-          ],
-          "default": "move",
-          "markdownDescription": "在包管理器中拖拽文件/文件夹时的默认操作。\n\n- **move**：默认移动（删除源文件）\n- **copy**：默认复制（保留源文件）\n- **ask**：每次都询问用户选择"
-        },
-        "AndreaNovelHelper.package.iconStyle": {
-          "anhName": "文件图标样式",
-          "type": "string",
-          "enum": [
-            "auto",
-            "theme",
-            "custom"
-          ],
-          "enumDescriptions": [
-            "自动（优先使用主题图标，无匹配时使用自定义图标）",
-            "仅使用主题图标（不替换任何图标）",
-            "使用自定义图标（始终使用内置语义图标）"
-          ],
-          "default": "auto",
-          "markdownDescription": "包管理器中资源文件的图标显示方式。\n\n- **auto**（推荐）：优先使用当前图标主题的图标，仅对 `.ojson5`（角色）、`.rjson5`（关系）、`.tjson5`（时间线）等特殊文件使用语义化图标\n- **theme**：完全使用图标主题的默认图标\n- **custom**：始终使用自定义的语义化图标（角色=`person`，关系=`type-hierarchy`，时间线=`git-branch`）"
-        },
-        "AndreaNovelHelper.typo.debug.llmTrace": {
-          "anhName": "LLM调试追踪",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "调试：输出客户端直连大模型的请求与流式响应到 Output（包含提示词与分段输出，谨慎开启）。"
-        },
-        "AndreaNovelHelper.typo.debug.serverTrace": {
-          "anhName": "服务端调试追踪",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "调试：输出服务端 HTTP /correct 与 /correct/llm 的请求/响应概要到 Output。"
-        },
-        "AndreaNovelHelper.typo.persistence.enabled": {
-          "anhName": "启用持久化",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用错别字数据持久化存储。开启后，错别字扫描结果将保存到本地文件，重启后可恢复之前的扫描结果。"
-        },
-        "AndreaNovelHelper.typo.persistence.autoCleanup": {
-          "anhName": "自动清理",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "自动清理过期的错别字数据文件。"
-        },
-        "AndreaNovelHelper.typo.persistence.maxAgeDays": {
-          "anhName": "数据保存天数",
-          "type": "number",
-          "default": 30,
-          "minimum": 1,
-          "maximum": 365,
-          "markdownDescription": "错别字数据文件的最大保存天数，超过此时间的文件将被自动清理。"
-        },
-        "AndreaNovelHelper.typo.debug.compactTrace": {
-          "anhName": "压缩调试输出",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "调试输出是否压缩为单行（合并换行与多余空白）。"
-        },
-        "AndreaNovelHelper.typo.debug.traceMaxLen": {
-          "anhName": "调试输出最大长度",
-          "type": "number",
-          "default": 1200,
-          "minimum": 200,
-          "maximum": 10000,
-          "markdownDescription": "单条调试输出最大长度（字符）。"
-        },
-        "AndreaNovelHelper.typo.llm.model": {
-          "anhName": "服务端LLM模型",
-          "type": "string",
-          "default": "deepseek-v3",
-          "markdownDescription": "LLM 模型（可选）。为空表示由服务端默认。"
-        },
-        "AndreaNovelHelper.typo.llm.apiKey": {
-          "anhName": "服务端API密钥",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "LLM API Key（可选）。为空表示由服务端默认。"
-        },
-        "AndreaNovelHelper.typo.llm.apiBase": {
-          "anhName": "服务端API地址",
-          "type": "string",
-          "default": "",
-          "markdownDescription": "LLM API Base（可选）。为空表示由服务端默认。"
-        },
-        "AndreaNovelHelper.typo.batchSize": {
-          "anhName": "批次大小",
-          "type": "number",
-          "default": 30,
-          "minimum": 1,
-          "maximum": 200,
-          "markdownDescription": "批量调用每次携带的句子数，建议 10-50（macro）/ 5-20（llm）。"
-        },
-        "AndreaNovelHelper.typo.docConcurrency": {
-          "anhName": "文档并发数",
-          "type": "number",
-          "default": 3,
-          "minimum": 1,
-          "maximum": 10,
-          "markdownDescription": "每个文档并发扫描段落的最大请求数（限流，以免阻塞外部服务）。"
-        },
-        "AndreaNovelHelper.typo.docGroupSize": {
-          "anhName": "文档分组大小",
-          "type": "number",
-          "default": 3,
-          "minimum": 1,
-          "maximum": 20,
-          "markdownDescription": "同一文档连续段落的合并扫描组大小（尽可能给大模型更长的上下文）。"
-        },
-        "AndreaNovelHelper.typo.timeoutMs": {
-          "anhName": "超时时间",
-          "type": "number",
-          "default": 30000,
-          "minimum": 1000,
-          "maximum": 300000,
-          "markdownDescription": "调用错别字服务的超时时间（毫秒）。LLM 模式建议 120000。"
-        },
-        "AndreaNovelHelper.typo.enableHighlight": {
-          "anhName": "启用高亮",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "是否为错别字添加标黄背景（诊断之外的视觉装饰）。"
-        },
-        "AndreaNovelHelper.typo.highlightColor": {
-          "anhName": "高亮颜色",
-          "type": "string",
-          "default": "#fff3a3",
-          "markdownDescription": "错别字标黄背景色（CSS 颜色，如 #fff3a3）。"
-        },
-        "AndreaNovelHelper.typo.maxDocs": {
-          "anhName": "最大文档数",
-          "type": "number",
-          "default": 10,
-          "minimum": 1,
-          "maximum": 200,
-          "markdownDescription": "错别字内存数据库最大文档数（LRU 淘汰）。"
-        },
-        "AndreaNovelHelper.typo.keepCacheOnClose": {
-          "anhName": "关闭时保留缓存",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "关闭编辑器后是否保留错别字扫描缓存（由 LRU 控制释放）。关闭则在关闭文档时立即清理缓存。"
-        },
-        "AndreaNovelHelper.typo.warningLevel": {
-          "anhName": "警告级别",
-          "type": "string",
-          "enum": [
-            "error",
-            "warning",
-            "information",
-            "hint"
-          ],
-          "default": "warning",
-          "markdownDescription": "错别字诊断的警告级别：error（错误）、warning（警告）、information（信息）、hint（提示）。"
-        },
-        "AndreaNovelHelper.sensitiveWords.warningLevel": {
-          "anhName": "敏感词警告级别",
-          "type": "string",
-          "enum": [
-            "error",
-            "warning",
-            "information",
-            "hint"
-          ],
-          "default": "error",
-          "markdownDescription": "敏感词诊断的警告级别：error（错误）、warning（警告）、information（信息）、hint（提示）。"
-        },
-        "AndreaNovelHelper.webdav.sync.strategy": {
-          "anhName": "同步策略",
-          "type": "string",
-          "default": "timestamp",
-          "enum": [
-            "timestamp",
-            "size",
-            "both",
-            "content"
-          ],
-          "enumDescriptions": [
-            "基于文件修改时间戳比较（默认）",
-            "基于文件大小比较",
-            "同时比较时间戳和文件大小",
-            "基于文件内容哈希比较（最准确但较慢）"
-          ],
-          "markdownDescription": "WebDAV 同步策略：选择如何判断文件是否需要同步。timestamp 基于修改时间，size 基于文件大小，both 同时检查两者，content 基于内容哈希。"
-        },
-        "AndreaNovelHelper.webdav.sync.timeTolerance": {
-          "anhName": "时间容差",
-          "type": "number",
-          "default": 15000,
-          "minimum": 0,
-          "maximum": 60000,
-          "markdownDescription": "时间戳比较的容差（毫秒）。由于网络传输和服务器处理延迟，允许一定的时间差异。设置为 0 表示严格比较。"
-        },
-        "AndreaNovelHelper.webdav.sync.enableSmartComparison": {
-          "anhName": "启用智能比较",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "启用智能比较算法。结合文件大小和修改时间进行更准确的同步判断，减少误同步。"
-        },
-        "AndreaNovelHelper.webdav.sync.ignoredDirectories": {
-          "anhName": "忽略目录",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            ".git",
-            "node_modules",
-            ".pixi",
-            ".venv",
-            "__pycache__",
-            ".pytest_cache",
-            ".gradle",
-            ".mvn",
-            "bin",
-            "obj",
-            ".vs",
-            ".idea",
-            ".next",
-            ".nuxt",
-            ".cache",
-            ".tmp",
-            "tmp",
-            ".cargo",
-            "vendor",
-            "coverage",
-            ".nyc_output",
-            ".tox",
-            ".nox",
-            ".dart_tool",
-            ".pub-cache"
-          ],
-          "markdownDescription": "WebDAV 同步时忽略的目录列表。默认忽略版本控制、依赖包、编译缓存等目录。IDE 和编辑器目录（如 .vscode、.idea 等）不会被忽略，以支持跨设备的开发环境同步。"
-        },
-        "AndreaNovelHelper.webdav.sync.ignoredFiles": {
-          "anhName": "忽略文件",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            ".DS_Store",
-            "Thumbs.db",
-            "desktop.ini",
-            "*.tmp",
-            "*.temp",
-            "*.log",
-            "*.pid",
-            "*.lock"
-          ],
-          "markdownDescription": "WebDAV 同步时忽略的文件模式列表。支持通配符匹配，用于过滤系统文件、临时文件等。"
-        },
-        "AndreaNovelHelper.webdav.sync.ignoreAppDataDirectories": {
-          "anhName": "忽略应用数据目录",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "是否忽略应用程序内部数据目录（如 .anh-fsdb）。启用时不会同步写作统计、文件追踪等内部数据，推荐保持启用以避免数据冲突。"
-        },
-        "AndreaNovelHelper.webdav.sync.showDiffTable": {
-          "anhName": "显示差异表",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "同步完成后是否在输出日志中显示文件差异表。启用后可以查看本次同步涉及的所有文件变更详情。"
-        },
-        "AndreaNovelHelper.webdav.sync.enableMetadataSidecar": {
-          "anhName": "启用元数据缓存文件",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "是否启用缓存文件元数据功能。启用后会为每个文件创建包含详细元数据的缓存文件，提供更丰富的同步信息。"
-        },
-        "AndreaNovelHelper.webdav.sync.metadataSidecarSuffix": {
-          "anhName": "元数据文件后缀",
-          "type": "string",
-          "default": ".anhmeta.json",
-          "markdownDescription": "缓存文件的后缀名。默认为 .anhmeta.json，用于存储文件的元数据信息。"
-        },
-        "AndreaNovelHelper.webdav.sync.skipDatabaseAccess": {
-          "anhName": "跳过数据库访问",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "跳过数据库访问以提升同步速度。启用后缓存数据将不会从文件追踪数据库获取完整信息，显著提升同步性能。"
-        },
-        "AndreaNovelHelper.webdav.sync.autoSync.enabled": {
-          "anhName": "启用自动同步",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "是否启用定时自动同步。启用后将按设定的时间间隔自动执行双向同步。"
-        },
-        "AndreaNovelHelper.webdav.sync.autoSync.intervalMinutes": {
-          "anhName": "自动同步间隔",
-          "type": "number",
-          "default": 30,
-          "minimum": 1,
-          "maximum": 1440,
-          "markdownDescription": "定时同步的时间间隔（分钟）。范围：1-1440分钟（1分钟到24小时）。"
-        },
-        "AndreaNovelHelper.webdav.sync.autoSync.method": {
-          "anhName": "自动同步方式",
-          "type": "string",
-          "enum": [
-            "bidirectional",
-            "upload",
-            "download"
-          ],
-          "default": "bidirectional",
-          "markdownDescription": "定时同步的方法。bidirectional: 双向同步（默认），upload: 仅上传本地文件到服务器，download: 仅从服务器下载文件到本地。"
-        },
-        "AndreaNovelHelper.autoGit.enabled": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "启用自动Git",
-          "markdownDescription": "是否启用AutoGit功能。启用后将自动检测Git仓库变更并执行自动提交和同步。"
-        },
-        "AndreaNovelHelper.autoGit.checkIntervalSeconds": {
-          "type": "number",
-          "default": 30,
-          "minimum": 10,
-          "maximum": 300,
-          "anhName": "检查间隔秒数",
-          "markdownDescription": "检查Git HEAD变更的时间间隔（秒）。范围：10-300秒。"
-        },
-        "AndreaNovelHelper.autoGit.commitMessageTemplate": {
-          "type": "string",
-          "default": "Auto commit: {timestamp}",
-          "anhName": "提交消息模板",
-          "markdownDescription": "自动提交的消息模板。可使用变量：{timestamp}（时间戳）、{files}（变更文件数）、{branch}（分支名）。"
-        },
-        "AndreaNovelHelper.autoGit.autoPull": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "自动拉取",
-          "markdownDescription": "检测到远程变更时是否自动拉取。启用后会在检测到远程HEAD变更时自动执行git pull。"
-        },
-        "AndreaNovelHelper.autoGit.autoPush": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "自动推送",
-          "markdownDescription": "本地提交后是否自动推送到远程仓库。启用后会在自动提交后执行git push。"
-        },
-        "AndreaNovelHelper.autoGit.includeUntracked": {
-          "type": "boolean",
-          "default": false,
-          "anhName": "包含未跟踪文件",
-          "markdownDescription": "是否包含未跟踪的文件。启用后会自动添加新文件到Git暂存区。"
-        },
-        "AndreaNovelHelper.autoGit.compactStatus": {
-          "type": "boolean",
-          "default": false,
-          "scope": "window",
-          "anhName": "简洁状态栏",
-          "markdownDescription": "ANH:Sync 状态栏简洁模式：开启时仅显示 'ANH:Sync'，不显示具体的 Git/WebDAV 状态。"
-        },
-        "AndreaNovelHelper.autoGit.excludePatterns": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "*.tmp",
-            "*.log",
-            ".DS_Store",
-            "Thumbs.db"
-          ],
-          "anhName": "排除模式",
-          "markdownDescription": "自动提交时排除的文件模式列表。支持通配符匹配。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.enabled": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "启用智能标签组锁定",
-          "markdownDescription": "启用智能标签组锁定功能。当分屏仅包含ANH扩展提供的各种窗体（如预览面板、批注管理、双大纲等）时，自动锁定该分屏以避免新窗体在其中打开。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.enableBuiltinTypes": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "启用内置类型",
-          "markdownDescription": "启用内置智能锁定窗体类型。禁用后，只有自定义配置的窗体类型会参与智能锁定。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.excludeRoleEditor": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "排除角色编辑器",
-          "markdownDescription": "排除角色卡编辑器（andrea.roleEditor）参与智能锁定。默认排除，设为false可让角色卡编辑器参与智能锁定。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.excludeDiffEditor": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "排除差异编辑器",
-          "markdownDescription": "排除差异编辑器（vscode.diff-editor）参与智能锁定。默认排除，设为false可让差异编辑器参与智能锁定。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.excludeNotesDiff": {
-          "type": "boolean",
-          "default": true,
-          "anhName": "排除笔记差异",
-          "markdownDescription": "排除Notes差异编辑器（notes.diff）参与智能锁定。默认排除，设为false可让Notes差异编辑器参与智能锁定。"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.customWebviewTypes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "anhName": "自定义WebView类型",
-          "markdownDescription": "自定义参与智能锁定的WebView类型列表。例如：['my-extension.preview', 'another.webview']"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.customEditorTypes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "anhName": "自定义编辑器类型",
-          "markdownDescription": "自定义参与智能锁定的编辑器类型列表。例如：['my-extension.editor', 'another.custom-editor']"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.customUriSchemes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "anhName": "自定义URI方案",
-          "markdownDescription": "自定义参与智能锁定的URI方案列表。例如：['my-scheme', 'another-scheme']"
-        },
-        "AndreaNovelHelper.smartTabGroupLock.customNotebookTypes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "anhName": "自定义笔记本类型",
-          "markdownDescription": "自定义参与智能锁定的笔记本类型列表。例如：['my-notebook', 'another-notebook']"
-        },
-        "AndreaNovelHelper.database.backend": {
-          "anhName": "数据库后端",
-          "type": "string",
-          "enum": [
-            "json",
-            "sqlite"
-          ],
-          "default": "json",
-          "markdownDescription": "数据库后端类型：\n- **json**: JSON文件存储（默认，兼容旧版本）\n- **sqlite**: SQLite数据库（推荐，性能更好）\n\n⚠️ 切换后端时会提示运行数据同步"
-        },
-        "AndreaNovelHelper.database.sqlite.enableWAL": {
-          "anhName": "启用WAL模式",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "启用SQLite的WAL（Write-Ahead Logging）模式，提升并发性能"
-        },
-        "AndreaNovelHelper.database.sqlite.cacheSize": {
-          "anhName": "缓存大小",
-          "type": "number",
-          "default": 2560,
-          "minimum": 256,
-          "maximum": 10240,
-          "markdownDescription": "SQLite缓存大小（页数），默认2560页约10MB"
-        },
-        "AndreaNovelHelper.database.sqlite.enableMmap": {
-          "anhName": "启用内存映射",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "启用SQLite的内存映射IO，提升读取性能"
-        },
-        "AndreaNovelHelper.database.sqlite.initQueueTimeoutMs": {
-          "anhName": "初始化队列等待时长",
-          "type": "number",
-          "default": 15000,
-          "minimum": 1000,
-          "maximum": 120000,
-          "markdownDescription": "SQLite 后端初始化时，文件追踪写操作在内存队列中等待的最长时间（毫秒）。超过该时长后，会临时回退到 JSON 分片持久化以避免继续堆积。"
-        },
-        "AndreaNovelHelper.database.autoMigrate": {
-          "anhName": "自动迁移",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "切换数据库后端时自动运行数据迁移（否则需要手动运行迁移命令）"
-        },
-        "AndreaNovelHelper.startupSnapshot.enabled": {
-          "anhName": "启用启动快照",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "%config.startupSnapshot.enabled.description%"
-        },
-        "AndreaNovelHelper.startupSnapshot.deleteOnDisable": {
-          "anhName": "禁用时删除",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "%config.startupSnapshot.deleteOnDisable.description%"
-        },
-        "AndreaNovelHelper.startupSnapshot.showNotification": {
-          "anhName": "显示通知",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "%config.startupSnapshot.showNotification.description%"
-        },
-        "andrea.typst.cliPath": {
-          "anhName": "CLI路径",
-          "type": "string",
-          "default": "typst",
-          "description": "Typst CLI 可执行路径（留空使用 PATH）"
-        },
-        "andrea.typst.templatesDir": {
-          "anhName": "模板目录",
-          "type": "string",
-          "default": "${workspaceFolder}/templates/typst",
-          "description": "扩展外置模板默认目录"
-        },
-        "andrea.typst.externalTemplatesDir": {
-          "anhName": "外部模板目录",
-          "type": "string",
-          "default": "${workspaceFolder}/novel-helper/templates/typst",
-          "description": "项目 novel-helper 目录下模板路径"
-        },
-        "andrea.typst.defaultTemplate": {
-          "anhName": "默认模板",
-          "type": "string",
-          "default": "sample",
-          "description": "默认模板包名称"
-        },
-        "andrea.typst.defaultRenderer": {
-          "anhName": "默认 Typst 渲染器",
-          "type": "string",
-          "default": "internal",
-          "markdownDescription": "Typst 内容生成器。`internal` 使用 ANH 内置 Liquid 模板渲染；脚本可通过 `ctx.renderers.registerTypst` 或 `ctx.processors.registerTypst` 注册新的渲染器 ID。"
-        },
-        "andrea.typst.output.format": {
-          "anhName": "导出格式",
-          "type": "string",
-          "enum": [
-            "pdf",
-            "png",
-            "svg"
-          ],
-          "default": "pdf",
-          "description": "导出格式"
-        },
-        "andrea.typst.output.ppi": {
-          "anhName": "导出分辨率",
-          "type": "number",
-          "default": 144,
-          "description": "PNG 导出分辨率（PPI）"
-        },
-        "andrea.typst.pages": {
-          "anhName": "导出页码范围",
-          "type": "string",
-          "default": "",
-          "description": "导出页码范围（例如 2,3-6,8-）"
-        },
-        "andrea.typst.font.paths": {
-          "anhName": "字体路径",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "额外字体搜索路径"
-        },
-        "andrea.typst.cleanupTemp": {
-          "anhName": "清理临时文件",
-          "type": "boolean",
-          "default": false,
-          "description": "导出后是否自动清理临时编译目录 build/typst/tmp-*（默认不清理，便于诊断）"
-        },
-        "andrea.typst.preview.storage": {
-          "anhName": "预览存储方式",
-          "type": "string",
-          "enum": [
-            "memory",
-            "file"
-          ],
-          "default": "memory",
-          "markdownDescription": "Typst预览文件存储方式：\n- `memory`：存储在虚拟内存盘上（andrea-typst://），实时预览\n- `file`：存储在临时文件目录中，使用绝对路径"
-        },
-        "andrea.typst.preview.tempDir": {
-          "anhName": "预览临时目录",
-          "type": "string",
-          "default": "${workspaceFolder}/build/typst/preview",
-          "markdownDescription": "Typst预览临时文件目录（当preview.storage为'file'时使用）"
-        },
-        "AndreaNovelHelper.scripts.root": {
-          "anhName": "脚本根目录",
-          "type": "string",
-          "default": "novel-helper/scripts",
-          "markdownDescription": "脚本运行侧栏的根目录"
-        },
-        "AndreaNovelHelper.scripts.defaultPlainTextProcessor": {
-          "anhName": "默认纯文本处理器",
-          "type": "string",
-          "default": "internal",
-          "markdownDescription": "复制纯文本和导出 TXT 时使用的处理器。`internal` 使用 ANH 内置 Markdown/TXT 转纯文本逻辑；脚本可通过 `ctx.processors.registerPlainText` 注册新的处理器 ID。"
-        },
-        "AndreaNovelHelper.autoScroll.enabled": {
-          "anhName": "启用自动滚动",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "启用编辑器自动滚动到文档末尾功能。当文档内容变化时，自动滚动到指定的比例位置。"
-        },
-        "AndreaNovelHelper.autoScroll.ratio": {
-          "anhName": "滚动比例",
-          "type": "number",
-          "default": 1,
-          "minimum": 0.1,
-          "maximum": 0.7,
-          "markdownDescription": "自动滚动的目标比例（0.1-0.7）。1.0 表示完全滚动到底部，0.5 表示滚动到中间位置。"
-        },
-        "AndreaNovelHelper.autoScroll.debounceDelay": {
-          "anhName": "防抖延迟",
-          "type": "number",
-          "default": 0,
-          "minimum": 0,
-          "maximum": 2000,
-          "markdownDescription": "自动滚动的防抖延迟时间（毫秒）。避免频繁滚动导致的抖动。 如果0 则立即触发"
-        },
-        "AndreaNovelHelper.whatsNew.autoShow": {
-          "anhName": "自动显示 What's New",
-          "type": "boolean",
-          "default": true,
-          "description": "更新到新版后自动显示 What's New 页面"
-        }
-      }
-    },
-    "menus": {
-      "explorer/context": [
-        {
-          "command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
-          "when": "andrea.anh.enabled && resourceExtname == .json5",
-          "group": "navigation"
-        },
-        {
-          "command": "andrea.typst.exportFromExplorer",
-          "when": "resourceExtname == .md",
-          "group": "navigation@100"
-        },
-        {
-          "command": "andrea.typst.exportFromExplorer",
-          "when": "resourceExtname == .txt",
-          "group": "navigation@100"
-        },
-        {
-          "command": "andrea.typst.exportFromExplorer",
-          "when": "explorerResourceIsFolder",
-          "group": "navigation@100"
-        },
-        {
-          "command": "AndreaNovelHelper.fileTracker.openShardForFile",
-          "when": "resourceScheme == file && config.AndreaNovelHelper.database.backend == json",
-          "group": "navigation@120"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "andrea.configureDocRoles",
-          "when": "view == docRolesView || view == docRolesExplorerView",
-          "group": "navigation@100"
-        },
-        {
-          "command": "andrea.configureAllRoles",
-          "when": "view == roleHierarchyView",
-          "group": "navigation@100"
-        },
-        {
-          "command": "andrea.scripts.openFolder",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@1",
-          "icon": "$(folder-opened)"
-        },
-        {
-          "command": "andrea.scripts.openMcpConfig",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@2",
-          "icon": "$(gear)"
-        },
-        {
-          "command": "andrea.scripts.toggleMcpServers",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@4",
-          "icon": "$(server-process)"
-        },
-        {
-          "command": "andrea.scripts.selectPlainTextProcessor",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@4.5",
-          "icon": "$(settings-gear)"
-        },
-        {
-          "command": "andrea.scripts.selectTypstRenderer",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@4.6",
-          "icon": "$(symbol-method)"
-        },
-        {
-          "command": "andrea.scripts.newScript",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@5",
-          "icon": "$(new-file)"
-        },
-        {
-          "command": "andrea.scripts.refresh",
-          "when": "view == andrea.scriptsView",
-          "group": "navigation@6",
-          "icon": "$(refresh)"
-        },
-        {
-          "command": "andrea.openProjectSettings",
-          "when": "view == andrea.settingsView",
-          "group": "navigation@1",
-          "icon": "$(settings-gear)"
-        }
-      ],
-      "view/item/context": [
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createCharacterGallery",
-          "group": "0_create@2"
-        },
-        {
-          "when": "view == andrea.scriptsView && viewItem == andrea.script.file",
-          "command": "andrea.scripts.run",
-          "group": "inline@1",
-          "icon": "$(run)"
-        },
-        {
-          "when": "view == andrea.scriptsView && viewItem == andrea.mcp.server.enabled",
-          "command": "andrea.scripts.toggleSingleServer",
-          "group": "navigation@1",
-          "icon": "$(trash)"
-        },
-        {
-          "when": "view == andrea.scriptsView && viewItem == andrea.mcp.server.disabled",
-          "command": "andrea.scripts.toggleSingleServer",
-          "group": "navigation@1",
-          "icon": "$(add)"
-        },
-        {
-          "when": "view == andrea.scriptsView && viewItem == andrea.script.dir",
-          "command": "andrea.scripts.newScript",
-          "group": "inline@1"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "andrea.openProjectSettings",
-          "group": "0_create@0"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.projectInitWizard.graphical",
-          "group": "0_create@1"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createSensitiveWords",
-          "group": "0_create@3"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createVocabulary",
-          "group": "0_create@4"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createRoleFile",
-          "group": "0_create@5"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createRelationshipFile",
-          "group": "0_create@6"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createTimelineFile",
-          "group": "0_create@7"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createRegexPatterns",
-          "group": "0_create@8"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.showGuide",
-          "group": "0_create@9"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.showGuideDoc",
-          "group": "0_create@10"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.createSubPackage",
-          "group": "1_package@1"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.deleteNode",
-          "group": "2_deletion"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.openFile",
-          "group": "3_open"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == projectConfigFile || viewItem == missingProjectConfigFile)",
-          "command": "AndreaNovelHelper.openProjectConfigFile",
-          "group": "3_open"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile)",
-          "command": "AndreaNovelHelper.openWith",
-          "group": "3_open"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == projectConfigFile || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.revealInExplorer",
-          "group": "3_open"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.renamePackage",
-          "group": "1_package@2"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.insertFileAbove",
-          "group": "1_modification@1"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.insertFolderAbove",
-          "group": "1_modification@2"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.insertFileBelow",
-          "group": "1_modification@3"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.insertFolderBelow",
-          "group": "1_modification@4"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.open",
-          "group": "3_open@1"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.openWith",
-          "group": "3_open@2"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.revealInOS",
-          "group": "3_open@3"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.rename",
-          "group": "2_modification@1"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.delete",
-          "group": "2_deletion@9"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.createNewFile",
-          "group": "0_create@1"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.createNewFolder",
-          "group": "0_create@2"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem == wordCountFolder",
-          "command": "AndreaNovelHelper.wordCount.enableManualOrdering",
-          "group": "4_order@1"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem == wordCountFolderManual",
-          "command": "AndreaNovelHelper.wordCount.disableManualOrdering",
-          "group": "4_order@1"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.generateIndexFromName",
-          "group": "4_order@2"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.clearIndex",
-          "group": "4_order@3"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.setIndexManual",
-          "group": "4_order@4"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.bulkGenerateIndices",
-          "group": "4_order@5"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.forceRecountHere",
-          "group": "9_force@1"
-        },
-        {
-          "when": "view == wordCountExplorer",
-          "command": "AndreaNovelHelper.wordCount.forceRecountAll",
-          "group": "9_force@2"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.rescanResourceFilesInFolder",
-          "group": "9_force@3"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.copy",
-          "group": "5_clip@1"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.cut",
-          "group": "5_clip@2"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem == wordCountFile",
-          "command": "WordCount.copyPlainText",
-          "group": "5_clip@4"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem == wordCountFile",
-          "command": "WordCount.exportTxt",
-          "group": "5_clip@5"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem == wordCountFile",
-          "command": "WordCount.exportTxtWithProcessor",
-          "group": "5_clip@5.5"
-        },
-        {
-          "when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
-          "command": "AndreaNovelHelper.wordCount.exportTypst",
-          "group": "5_clip@6"
-        },
-        {
-          "when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
-          "command": "AndreaNovelHelper.wordCount.paste",
-          "group": "5_clip@3"
-        },
-        {
-          "command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
-          "when": "view == packageManagerView && ( viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError)",
-          "group": "navigation"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.package.copy",
-          "group": "6_clip@1"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.package.cut",
-          "group": "6_clip@2"
-        },
-        {
-          "when": "view == packageManagerView && (viewItem == package || viewItem == externalRoleFolder)",
-          "command": "AndreaNovelHelper.package.paste",
-          "group": "6_clip@3"
-        },
-        {
-          "command": "andrea.webdav.openFile",
-          "when": "view == andrea.webdavFiles && viewItem == webdavFile",
-          "group": "navigation@1"
-        },
-        {
-          "command": "andrea.webdav.renameFile",
-          "when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
-          "group": "2_workspace@1"
-        },
-        {
-          "command": "andrea.webdav.copyFile",
-          "when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
-          "group": "2_workspace@2"
-        },
-        {
-          "command": "andrea.webdav.deleteFile",
-          "when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
-          "group": "2_workspace@3"
-        },
-        {
-          "command": "andrea.webdav.createFolder",
-          "when": "view == andrea.webdavFiles && viewItem == webdavFolder",
-          "group": "3_new@1"
-        },
-        {
-          "command": "andrea.webdav.uploadFile",
-          "when": "view == andrea.webdavFiles && viewItem == webdavFolder",
-          "group": "3_new@2"
-        },
-        {
-          "command": "andrea.commentsExplorer.openComment",
-          "when": "view == andrea.commentsExplorer && (viewItem == commentThread || viewItem == commentMessage)",
-          "group": "navigation@1"
-        },
-        {
-          "command": "andrea.commentsExplorer.toggleStatus",
-          "when": "view == andrea.commentsExplorer && viewItem == commentThread",
-          "group": "1_modification@1"
-        },
-        {
-          "command": "andrea.commentsExplorer.rebindFileToDocument",
-          "when": "view == andrea.commentsExplorer && viewItem == commentFile",
-          "group": "1_modification@1"
-        },
-        {
-          "command": "andrea.commentsExplorer.refresh",
-          "when": "view == andrea.commentsExplorer",
-          "group": "navigation@2"
-        },
-        {
-          "command": "andrea.commentsExplorer.search",
-          "when": "view == andrea.commentsExplorer",
-          "group": "navigation@3"
-        },
-        {
-          "command": "andrea.commentsExplorer.filterByStatus",
-          "when": "view == andrea.commentsExplorer",
-          "group": "2_filter@1"
-        },
-        {
-          "command": "andrea.commentsExplorer.clearFilter",
-          "when": "view == andrea.commentsExplorer",
-          "group": "2_filter@2"
-        },
-        {
-          "command": "andrea.commentsExplorer.exportComments",
-          "when": "view == andrea.commentsExplorer",
-          "group": "3_export@1"
-        },
-        {
-          "command": "andrea.commentsExplorer.exportToMarkdown",
-          "when": "view == andrea.commentsExplorer",
-          "group": "3_export@2"
-        },
-        {
-          "command": "andrea.commentsExplorer.exportToJson",
-          "when": "view == andrea.commentsExplorer",
-          "group": "3_export@3"
-        },
-        {
-          "when": "view == andrea.scriptsView && viewItem == andrea.script.file",
-          "command": "andrea.scripts.run",
-          "group": "navigation@1",
-          "icon": "$(run-all)"
-        },
-        {
-          "when": "view == andrea.scriptsView",
-          "command": "andrea.scripts.newScript",
-          "group": "0_create@1"
-        },
-        {
-          "when": "view == andrea.scriptsView",
-          "command": "andrea.scripts.renameScript",
-          "group": "2_modification@1"
-        },
-        {
-          "when": "view == andrea.scriptsView",
-          "command": "andrea.scripts.deleteScript",
-          "group": "2_deletion@9"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "myPreview.open",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation"
-        },
-        {
-          "command": "andrea.comments.open",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation@101"
-        },
-        {
-          "command": "AndreaNovelHelper.openDoubleOutline",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation"
-        },
-        {
-          "command": "AndreaNovelHelper.openOutlinePicker",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation@102"
-        },
-        {
-          "command": "AndreaNovelHelper.redirectOutlineHere",
-          "when": "resourceScheme == andrea-outline",
-          "group": "navigation@103"
-        },
-        {
-          "command": "AndreaNovelHelper.openTypstPreview",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation@104",
-          "icon": "$(preview)"
-        },
-        {
-          "command": "AndreaNovelHelper.changeTypstTemplate",
-          "when": "resourceScheme == andrea-typst",
-          "group": "navigation@105",
-          "icon": "$(settings)"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "andrea.formatDocument",
-          "when": "andrea.anh.enabled && (editorLangId == markdown || editorLangId == plaintext || editorLangId == json5)",
-          "group": "navigation@9"
-        },
-        {
-          "command": "andrea.formatDocument.addBlanks",
-          "when": "andrea.anh.enabled && (editorLangId == markdown || editorLangId == plaintext)",
-          "group": "navigation@9"
-        },
-        {
-          "command": "andrea.typst.exportCurrent",
-          "when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
-          "group": "navigation@100"
-        },
-        {
-          "when": "andrea.anh.enabled && editorHasSelection && (editorLangId == markdown || editorLangId == plaintext)",
-          "command": "andrea.comments.add",
-          "group": "1_modification@97"
-        },
-        {
-          "when": "andrea.anh.enabled && editorTextFocus && (editorLangId == markdown || editorLangId == plaintext)",
-          "command": "andrea.comments.open",
-          "group": "navigation@97"
-        },
-        {
-          "when": "andrea.anh.enabled && editorHasSelection",
-          "command": "AndreaNovelHelper.addRoleFromSelection",
-          "group": "navigation"
-        },
-        {
-          "when": "andrea.anh.enabled && editorHasSelection",
-          "command": "AndreaNovelHelper.addSensitiveWord",
-          "group": "navigation"
-        },
-        {
-          "when": "andrea.anh.enabled && editorHasSelection",
-          "command": "AndreaNovelHelper.addVocabulary",
-          "group": "navigation"
-        },
-        {
-          "when": "andrea.anh.enabled && editorTextFocus && resourceExtname == .md && editorHasSelection",
-          "command": "AndreaNovelHelper.showMarkdownFormatMenu",
-          "group": "1_modification@1"
-        },
-        {
-          "when": "andrea.anh.enabled && editorTextFocus && (editorLangId == markdown || editorLangId == plaintext)",
-          "command": "myPreview.copyPlainText",
-          "group": "navigation@8"
-        },
-        {
-          "when": "andrea.anh.enabled && editorHasSelection && (editorLangId == markdown || editorLangId == plaintext)",
-          "command": "andrea.typo.translateSelection",
-          "group": "navigation@98"
-        },
-        {
-          "when": "andrea.anh.enabled",
-          "command": "andrea-novel-helper.generateRandomCharacter",
-          "group": "navigation@99"
-        },
-        {
-          "when": "andrea.anh.enabled",
-          "command": "andrea-novel-helper.generateStepByStepCharacter",
-          "group": "navigation@100"
-        },
-        {
-          "command": "AndreaNovelHelper.fileTracker.openShardForFile",
-          "when": "resourceScheme == file && config.AndreaNovelHelper.database.backend == json",
-          "group": "navigation@120"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "AndreaNovelHelper.refreshRoles",
-          "group": "navigation"
-        },
-        {
-          "command": "AndreaNovelHelper.refreshSensitiveWords",
-          "group": "navigation"
-        },
-        {
-          "command": "AndreaNovelHelper.refreshVocabulary",
-          "group": "navigation"
-        }
-      ]
-    },
-    "views": {
-      "explorer": [
-        {
-          "id": "wordCountExplorer",
-          "name": "写作资源管理器（小说助手）",
-          "icon": "book",
-          "when": "andrea.anh.enabled"
-        },
-        {
-          "id": "docRolesExplorerView",
-          "name": "当前文章角色",
-          "icon": "account",
-          "when": "andrea.anh.enabled"
-        }
-      ],
-      "AndreaNovelHelperSidebar": [
-        {
-          "id": "packageManagerView",
-          "name": "包管理器",
-          "icon": "package"
-        },
-        {
-          "id": "docRolesView",
-          "name": "当前文章角色",
-          "icon": "person"
-        },
-        {
-          "id": "roleHierarchyView",
-          "name": "角色",
-          "icon": "organization"
-        }
-      ],
-      "AndreaCommentsSidebar": [
-        {
-          "id": "andrea.commentsExplorer",
-          "name": "%view.comments.explorer.name%",
-          "icon": "comment-discussion"
-        },
-        {
-          "id": "andrea.commentsPanelView",
-          "type": "webview",
-          "name": "%view.comments.panel.name%",
-          "icon": "comment"
-        },
-        {
-          "id": "andrea.commentsManagerView",
-          "type": "webview",
-          "name": "%view.comments.manager.name%",
-          "icon": "list-flat"
-        }
-      ],
-      "AndreaWebDAVSidebar": [
-        {
-          "id": "andrea.webdavPanel",
-          "type": "webview",
-          "name": "%view.webdav.panel.name%",
-          "icon": "cloud"
-        },
-        {
-          "id": "andrea.webdavFiles",
-          "name": "%view.webdav.files.name%",
-          "icon": "cloud-download"
-        },
-        {
-          "id": "andrea.autoGitPanel",
-          "name": "AutoGit 管理",
-          "icon": "git-branch"
-        }
-      ],
-      "AndreaScriptsSidebar": [
-        {
-          "id": "andrea.scriptsView",
-          "name": "%view.scripts.name%",
-          "icon": "run"
-        }
-      ],
-      "AndreaSettingsSidebar": [
-        {
-          "id": "andrea.settingsView",
-          "type": "webview",
-          "name": "设置",
-          "icon": "gear"
-        }
-      ]
-    },
-    "keybindings": [
-      {
-        "key": "enter",
-        "command": "andrea.smartEnter",
-        "when": "andrea.anh.enabled && editorTextFocus && andrea.typeset.smartEnterOn && !editorReadonly && (!suggestWidgetVisible || config.editor.acceptSuggestionOnEnter == 'off') && !inlineSuggestionVisible && !editorHasMultipleSelections && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode'"
-      },
-      {
-        "key": "ctrl+alt+i",
-        "command": "andrea.quickSettings",
-        "when": "editorTextFocus"
-      }
-    ]
-  },
-  "workspaces": [
-    "packages/webview",
-    "packages/enigo-keyboard"
-  ],
-  "scripts": {
-    "bundle:ext": "esbuild src/extension.ts --bundle --platform=node --format=cjs --target=node20 --external:vscode --main-fields=module,main --outfile=out/extension.js --sourcemap",
-    "build:webview": "npm --workspace=packages/webview run build",
-    "dev:webview": "npm --workspace=packages/webview run dev",
-    "vscode:prepublish": "npm run build:webview && npm run compile",
-    "compile": "node scripts/translate-nls2l10n.js && tsc -p ./",
-    "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src",
-    "test": "vscode-test",
-    "test:role-load-refresh": "npm run compile && mocha --ui tdd --require ./scripts/register-node-unit-test-env.js \"out/test/roleLoadRefresh.unit.test.js\"",
-    "publish:artifacts": "node scripts/publish-artifacts.js",
-    "mcp:test": "ts-node scripts/mcp-test.ts",
-    "mcp:run": "ts-node scripts/mcp-run.ts",
-    "mcp:bing-dom": "ts-node scripts/mcp-run.ts scripts/mcp-scripts/open-bing-get-dom.js",
-    "mcp:bing-input": "ts-node scripts/mcp-run.ts scripts/mcp-scripts/open-bing-input-zh.js"
-  },
-  "devDependencies": {
-    "@types/mocha": "^10.0.10",
-    "@types/node": "^20.19.11",
-    "@types/vscode": "^1.95.0",
-    "@typescript-eslint/eslint-plugin": "^8.31.1",
-    "@typescript-eslint/parser": "^8.31.1",
-    "@vscode/test-cli": "^0.0.11",
-    "@vscode/test-electron": "^2.5.2",
-    "esbuild": "^0.25.9",
-    "eslint": "^9.25.1",
-    "mocha": "^11.7.5",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
-  },
-  "dependencies": {
-    "@anh/enigo-keyboard": "^0.1.0",
-    "@cfworker/json-schema": "^4.1.1",
-    "@faker-js/faker": "^10.1.0",
-    "@modelcontextprotocol/sdk": "^1.22.0",
-    "@node-rs/jieba": "^2.0.1",
-    "@types/uuid": "^10.0.0",
-    "@vscode/sqlite3": "^5.1.8-vscode",
-    "ahocorasick": "^1.0.2",
-    "chardet": "^2.1.0",
-    "chart.js": "^4.5.0",
-    "chartjs-adapter-date-fns": "^3.0.0",
-    "fast-glob": "^3.3.3",
-    "font-list": "^1.5.1",
-    "iconv-lite": "^0.6.3",
-    "ignore": "^7.0.5",
-    "jschardet": "^3.1.4",
-    "json5": "^2.2.3",
-    "jsonc-parser": "^3.3.1",
-    "kuroshiro": "^1.2.0",
-    "kuroshiro-analyzer-kuromoji": "^1.1.0",
-    "liquidjs": "^10.24.0",
-    "memfs": "^4.17.2",
-    "pinyin-pro": "^3.28.1",
-    "transliteration": "^2.6.1",
-    "uuid": "^11.1.0",
-    "wanakana": "^5.3.1",
-    "webdav": "^5.7.0",
-    "zod": "^4.3.6"
-  }
+	"name": "andrea-novel-helper",
+	"displayName": "Novel Helper 小说助手 (Andrea Novel Helper)",
+	"description": "功能较完备的小说写作辅助：角色/词汇/敏感词库定义与管理、引用追踪与角色引用热力图、异步高亮匹配、双重大纲与包管理、写作时间与字数统计、正则表达式与补全、文件追踪、时间线与角色关系等。ANH 已作为面向小说创作的 IDE 环境构建，提供从资源管理到编辑辅助的一体化工具。(A full-featured novel-writing assistant integrated into ANH — an IDE-like environment for novel authors: define and manage characters, vocabulary and sensitive-word libraries; track references and character usage (including heatmaps); async highlight matching; dual outlines and package management; timelines and relationship graphs; writing time and word-count statistics; regex patterns, completions and editor integrations; file tracking, WebDAV/AutoGit sync and other end-to-end writing tools.)",
+	"version": "0.5.4",
+	"engines": {
+		"vscode": "^1.100.0"
+	},
+	"homepage": "https://anh.sirrus.cc",
+	"publisher": "andreafrederica",
+	"license": "MPL-2.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/AndreaFrederica/andrea-novel-helper.git"
+	},
+	"icon": "images/icon.png",
+	"categories": [
+		"Other"
+	],
+	"keywords": [
+		"andrea",
+		"novel",
+		"helper",
+		"writing",
+		"assistant",
+		"小说",
+		"小説",
+		"作家",
+		"写作",
+		"助手",
+		"角色",
+		"大纲",
+		"时间线",
+		"关系图",
+		"词汇",
+		"敏感词",
+		"统计",
+		"同步",
+		"WebDAV",
+		"AutoGit",
+		"脚本",
+		"MCP",
+		"Typst",
+		"错别字检查"
+	],
+	"activationEvents": [
+		"onLanguage:markdown",
+		"onLanguage:plaintext",
+		"onLanguage:ojson5",
+		"onLanguage:rjson5",
+		"onLanguage:tjson5",
+		"onFileSystem:andrea-outline",
+		"onCommand:andrea.openWritingDashboard",
+		"onCommand:andrea.openWritingDashboardWidget",
+		"onCommand:andrea.openRoleRelationshipGraph",
+		"onCommand:AndreaNovelHelper.openHello",
+		"onView:andrea.commentsExplorer",
+		"onView:andrea.commentsPanelView",
+		"onView:andrea.commentsManagerView",
+		"onWebviewPanel:andrea.writingDashboard",
+		"onWebviewPanel:andrea.writingDashboard.energy",
+		"onWebviewPanel:andrea.writingDashboard.heatmap",
+		"onWebviewPanel:andrea.writingDashboard.clock",
+		"onWebviewPanel:andrea.writingDashboard.profile",
+		"onWebviewPanel:andrea.writingDashboard.gantt",
+		"onWebviewPanel:andrea.writingDashboard.quadrant",
+		"onWebviewPanel:andrea.writingDashboard.plan",
+		"onWebviewPanel:andrea.writingDashboard.tasks",
+		"onWebviewPanel:andrea.writingDashboard.yearPlan",
+		"onWebviewPanel:andrea.writingDashboard.logs",
+		"onWebviewPanel:andrea.writingDashboard.timer",
+		"onWebviewPanel:andrea.roleRelationshipGraph",
+		"onWebviewPanel:andrea.guide",
+		"onWebviewPanel:andrea.guideDoc",
+		"onWebviewPanel:andrea.hello",
+		"onCommand:andrea.openWhatsNew",
+		"onWebviewPanel:whatsNew",
+		"onStartupFinished"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"customEditors": [
+			{
+				"viewType": "andrea.roleJson5Editor",
+				"displayName": "角色 JSON5 编辑器",
+				"selector": [
+					{
+						"filenamePattern": "**/*.json5"
+					},
+					{
+						"filenamePattern": "**/*.ojson5"
+					}
+				],
+				"priority": "default"
+			},
+			{
+				"viewType": "andrea.relationshipJson5Editor",
+				"displayName": "角色关系 JSON5 编辑器",
+				"selector": [
+					{
+						"filenamePattern": "**/*relationship*.json5"
+					},
+					{
+						"filenamePattern": "**/*.rjson5"
+					}
+				],
+				"priority": "default"
+			},
+			{
+				"viewType": "andrea.timelineJson5Editor",
+				"displayName": "时间线 JSON5 编辑器",
+				"selector": [
+					{
+						"filenamePattern": "**/*.tjson5"
+					}
+				],
+				"priority": "default"
+			},
+			{
+				"viewType": "andrea.timelineGanttJson5Editor",
+				"displayName": "时间线甘特图编辑器",
+				"selector": [
+					{
+						"filenamePattern": "**/*.tjson5"
+					}
+				],
+				"priority": "option"
+			}
+		],
+		"configurationDefaults": {
+			"[markdown]": {
+				"editor.quickSuggestions": {
+					"other": true,
+					"comments": true,
+					"strings": true
+				},
+				"editor.suggestOnTriggerCharacters": true,
+				"editor.wordBasedSuggestions": "allDocuments",
+				"editor.quickSuggestionsDelay": 0
+			},
+			"[plaintext]": {
+				"editor.quickSuggestions": {
+					"other": true,
+					"comments": true,
+					"strings": true
+				},
+				"editor.suggestOnTriggerCharacters": true,
+				"editor.wordBasedSuggestions": "allDocuments",
+				"editor.quickSuggestionsDelay": 0
+			}
+		},
+		"languages": [
+			{
+				"id": "wcignore",
+				"aliases": [
+					"WordCount Ignore",
+					"wcignore"
+				],
+				"extensions": [
+					".wcignore"
+				],
+				"configuration": "./language-configuration.json"
+			},
+			{
+				"id": "ftignore",
+				"aliases": [
+					"FileTracking Ignore",
+					"ftignore"
+				],
+				"extensions": [
+					".ftignore"
+				],
+				"configuration": "./language-configuration.json"
+			},
+			{
+				"id": "gitignore",
+				"aliases": [
+					"Git Ignore",
+					"gitignore"
+				],
+				"filenames": [
+					".gitignore"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "wcignore",
+				"scopeName": "source.wcignore",
+				"path": "./syntaxes/wcignore.tmLanguage.json"
+			},
+			{
+				"language": "ftignore",
+				"scopeName": "source.ftignore",
+				"path": "./syntaxes/ftignore.tmLanguage.json"
+			},
+			{
+				"language": "gitignore",
+				"scopeName": "source.gitignore.andrea",
+				"path": "./syntaxes/gitignore.tmLanguage.json"
+			},
+			{
+				"scopeName": "andrea.md.injection",
+				"path": "./syntaxes/andrea-md-injection.tmLanguage.json"
+			}
+		],
+		"snippets": [
+			{
+				"language": "markdown",
+				"path": "./snippets/def-md.json"
+			},
+			{
+				"language": "plaintext",
+				"path": "./snippets/def-txt.json"
+			}
+		],
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "AndreaNovelHelperSidebar",
+					"title": "%sidebar.anh.title%",
+					"icon": "images/anh_logo_dark.svg",
+					"when": "andrea.anh.enabled"
+				},
+				{
+					"id": "AndreaCommentsSidebar",
+					"title": "%sidebar.comments.title%",
+					"icon": "$(comment-discussion)",
+					"when": "andrea.anh.enabled"
+				},
+				{
+					"id": "AndreaWebDAVSidebar",
+					"title": "%sidebar.webdav.title%",
+					"icon": "$(cloud)",
+					"when": "andrea.anh.enabled"
+				},
+				{
+					"id": "AndreaScriptsSidebar",
+					"title": "%sidebar.scripts.title%",
+					"icon": "$(run)",
+					"when": "andrea.anh.enabled"
+				},
+				{
+					"id": "AndreaSettingsSidebar",
+					"title": "%sidebar.settings.title%",
+					"icon": "$(gear)",
+					"when": "andrea.anh.enabled"
+				}
+			]
+		},
+		"textDocumentContentProviders": [
+			{
+				"scheme": "andrea-outline",
+				"language": "markdown"
+			}
+		],
+		"commands": [
+			{
+				"command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
+				"title": "切换：使用角色卡管理器打开json5"
+			},
+			{
+				"command": "andrea.roleCardManager.open",
+				"title": "打开角色卡管理器测试页面"
+			},
+			{
+				"command": "andrea.ensureEnterOverrides",
+				"title": "%command.andrea.ensureEnterOverrides.title%",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.toggleSmartExit",
+				"title": "%command.andrea.toggleSmartExit.title%"
+			},
+			{
+				"command": "andrea.smartEnter",
+				"title": "%command.andrea.smartEnter.title%"
+			},
+			{
+				"command": "andrea.formatDocument",
+				"title": "%command.andrea.formatDocument.title%"
+			},
+			{
+				"command": "andrea.formatDocument.addBlanks",
+				"title": "%command.andrea.formatDocument.addBlanks.title%"
+			},
+			{
+				"command": "andrea.quickSettings",
+				"title": "%command.andrea.quickSettings.title%"
+			},
+			{
+				"command": "andrea.openGraphicalQuickSettings",
+				"title": "打开图形化快速设置",
+				"category": "Andrea Novel Helper",
+				"icon": "$(settings-gear)"
+			},
+			{
+				"command": "andrea.openSettingsWizard",
+				"title": "%command.andrea.openSettingsWizard.title%",
+				"category": "Andrea Novel Helper",
+				"icon": "$(wand)"
+			},
+			{
+				"command": "andrea.openProjectSettings",
+				"title": "打开项目设置",
+				"category": "Andrea Novel Helper",
+				"icon": "$(settings-gear)"
+			},
+			{
+				"command": "andrea.openWritingDashboard",
+				"title": "打开创作工作台",
+				"category": "Andrea Novel Helper",
+				"icon": "$(dashboard)"
+			},
+			{
+				"command": "andrea.openWritingDashboardWidget",
+				"title": "独立打开创作工作台组件",
+				"category": "Andrea Novel Helper",
+				"icon": "$(window)"
+			},
+			{
+				"command": "andrea.openRoleRelationshipGraph",
+				"title": "打开角色关系图谱",
+				"category": "Andrea Novel Helper",
+				"icon": "$(graph)"
+			},
+			{
+				"command": "andrea.configureMilestones",
+				"title": "%command.andrea.configureMilestones.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openTimeStats",
+				"title": "打开写作统计仪表板",
+				"category": "Andrea Novel Helper",
+				"icon": "$(graph)"
+			},
+			{
+				"command": "AndreaNovelHelper.exportTimeStatsCSV",
+				"title": "导出写作时间统计 CSV",
+				"category": "Andrea Novel Helper",
+				"icon": "$(file-code)"
+			},
+			{
+				"command": "andrea.toggleIndentFirst",
+				"title": "%command.andrea.toggleIndentFirst.title%"
+			},
+			{
+				"command": "andrea.toggleTrimTrailing",
+				"title": "%command.andrea.toggleTrimTrailing.title%"
+			},
+			{
+				"command": "andrea.changeBlankLines",
+				"title": "%command.andrea.changeBlankLines.title%"
+			},
+			{
+				"command": "andrea.changeIndentSize",
+				"title": "%command.andrea.changeIndentSize.title%"
+			},
+			{
+				"command": "andrea.manageEditorFontFamily",
+				"title": "%command.andrea.manageEditorFontFamily.title%"
+			},
+			{
+				"command": "andrea.toggleAutoPairs",
+				"title": "%command.andrea.toggleAutoPairs.title%"
+			},
+			{
+				"command": "andrea.toggleSmartEnter",
+				"title": "%command.andrea.toggleSmartEnter.title%"
+			},
+			{
+				"command": "myPreview.open",
+				"title": "%command.myPreview.open.title%",
+				"icon": {
+					"light": "images/preview_light.svg",
+					"dark": "images/preview_dark.svg"
+				}
+			},
+			{
+				"command": "andrea.typst.exportCurrent",
+				"title": "导出：使用Typst模板为PDF/图片"
+			},
+			{
+				"command": "andrea.typst.exportFromExplorer",
+				"title": "导出：使用Typst模板",
+				"icon": {
+					"light": "$(export)",
+					"dark": "$(export)"
+				}
+			},
+			{
+				"command": "AndreaNovelHelper.openTypstPreview",
+				"title": "打开Typst实时预览",
+				"icon": {
+					"light": "$(preview)",
+					"dark": "$(preview)"
+				}
+			},
+			{
+				"command": "AndreaNovelHelper.changeTypstTemplate",
+				"title": "切换Typst模板",
+				"icon": {
+					"light": "$(settings)",
+					"dark": "$(settings)"
+				}
+			},
+			{
+				"command": "myPreview.copyPlainText",
+				"title": "%command.myPreview.copyPlainText.title%"
+			},
+			{
+				"command": "andrea.comments.open",
+				"title": "%command.comments.open.title%",
+				"icon": {
+					"light": "images/comments_light.svg",
+					"dark": "images/comments_dark.svg"
+				}
+			},
+			{
+				"command": "andrea.comments.add",
+				"title": "%command.comments.add.title%"
+			},
+			{
+				"command": "andrea.comments.resolve",
+				"title": "%command.comments.resolve.title%"
+			},
+			{
+				"command": "andrea.comments.reopen",
+				"title": "%command.comments.reopen.title%"
+			},
+			{
+				"command": "andrea.commentsExplorer.toggleStatus",
+				"title": "%command.commentsExplorer.toggleStatus.title%",
+				"icon": {
+					"light": "$(check)",
+					"dark": "$(check)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.rebindFileToDocument",
+				"title": "%command.commentsExplorer.rebindFileToDocument.title%",
+				"icon": {
+					"light": "$(file-symlink-file)",
+					"dark": "$(file-symlink-file)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.openComment",
+				"title": "%command.commentsExplorer.openComment.title%",
+				"icon": {
+					"light": "$(go-to-file)",
+					"dark": "$(go-to-file)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.refresh",
+				"title": "%command.commentsExplorer.refresh.title%",
+				"icon": {
+					"light": "$(refresh)",
+					"dark": "$(refresh)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.search",
+				"title": "%command.commentsExplorer.search.title%",
+				"icon": {
+					"light": "$(search)",
+					"dark": "$(search)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.filterByStatus",
+				"title": "%command.commentsExplorer.filterByStatus.title%",
+				"icon": {
+					"light": "$(filter)",
+					"dark": "$(filter)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.clearFilter",
+				"title": "%command.commentsExplorer.clearFilter.title%",
+				"icon": {
+					"light": "$(clear-all)",
+					"dark": "$(clear-all)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.exportComments",
+				"title": "%command.commentsExplorer.exportComments.title%",
+				"icon": {
+					"light": "$(export)",
+					"dark": "$(export)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.exportToMarkdown",
+				"title": "%command.commentsExplorer.exportToMarkdown.title%",
+				"icon": {
+					"light": "$(markdown)",
+					"dark": "$(markdown)"
+				}
+			},
+			{
+				"command": "andrea.commentsExplorer.exportToJson",
+				"title": "%command.commentsExplorer.exportToJson.title%",
+				"icon": {
+					"light": "$(json)",
+					"dark": "$(json)"
+				}
+			},
+			{
+				"command": "andrea.scripts.openMcpConfig",
+				"title": "打开 MCP 配置",
+				"icon": "$(gear)"
+			},
+			{
+				"command": "andrea.scripts.toggleMcpServers",
+				"title": "启用/禁用 MCP 服务器",
+				"icon": "$(plug)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.copilot.exportPromptsToWorkspace",
+				"title": "导出内置 Copilot 提示到当前项目",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.toggleSingleServer",
+				"title": "切换 MCP 服务器启用状态",
+				"icon": "$(toggle-layout)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.reloadExtensions",
+				"title": "重新加载脚本扩展",
+				"icon": "$(refresh)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.selectPlainTextProcessor",
+				"title": "选择默认纯文本处理器",
+				"icon": "$(settings-gear)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.selectTypstRenderer",
+				"title": "选择默认 Typst 渲染器",
+				"icon": "$(symbol-method)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.runPlainTextProcessor",
+				"title": "使用脚本处理器处理当前文档",
+				"icon": "$(symbol-method)",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.runWithServers",
+				"title": "选择服务器运行",
+				"icon": "$(play)"
+			},
+			{
+				"command": "WordCount.exportTxt",
+				"title": "%command.wordCount.exportTxt.title%"
+			},
+			{
+				"command": "WordCount.exportTxtWithProcessor",
+				"title": "导出为 TXT（选择处理器）"
+			},
+			{
+				"command": "WordCount.copyPlainText",
+				"title": "%command.wordCount.copyPlainText.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.addRoleFromSelection",
+				"title": "%command.addRoleFromSelection.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.refreshRoles",
+				"title": "%command.refreshRoles.title%"
+			},
+			{
+				"command": "andrea.configureAllRoles",
+				"title": "配置：全部角色显示"
+			},
+			{
+				"command": "andrea.configureDocRoles",
+				"title": "配置：当前文章角色显示"
+			},
+			{
+				"command": "AndreaNovelHelper.addSensitiveWord",
+				"title": "%command.addSensitiveWord.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.refreshSensitiveWords",
+				"title": "%command.refreshSensitiveWords.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.addVocabulary",
+				"title": "%command.addVocabulary.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.refreshVocabulary",
+				"title": "%command.refreshVocabulary.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openDoubleOutline",
+				"title": "%command.openDoubleOutline.title%",
+				"icon": {
+					"light": "images/checklist_light.svg",
+					"dark": "images/checklist_dark.svg"
+				}
+			},
+			{
+				"command": "AndreaNovelHelper.openOutlinePicker",
+				"title": "ANH:打开大纲 New",
+				"icon": {
+					"light": "images/checklist_light.svg",
+					"dark": "images/checklist_dark.svg"
+				}
+			},
+			{
+				"command": "AndreaNovelHelper.redirectOutlineHere",
+				"title": "ANH:打开新大纲窗体",
+				"icon": {
+					"light": "images/checklist_light.svg",
+					"dark": "images/checklist_dark.svg"
+				}
+			},
+			{
+				"command": "AndreaNovelHelper.refreshOutlineDir",
+				"title": "%command.refreshOutlineDir.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.refreshOutlineFile",
+				"title": "%command.refreshOutlineFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openFile",
+				"title": "%command.openFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openProjectConfigFile",
+				"title": "打开项目设置文件"
+			},
+			{
+				"command": "AndreaNovelHelper.deleteNode",
+				"title": "%command.deleteNode.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createCharacterGallery",
+				"title": "%command.createCharacterGallery.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createSensitiveWords",
+				"title": "%command.createSensitiveWords.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createVocabulary",
+				"title": "%command.createVocabulary.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createRoleFile",
+				"title": "%command.createRoleFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createRelationshipFile",
+				"title": "%command.createRelationshipFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createTimelineFile",
+				"title": "%command.createTimelineFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createSubPackage",
+				"title": "%command.createSubPackage.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.renamePackage",
+				"title": "%command.renamePackage.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.createRegexPatterns",
+				"title": "%command.createRegexPatterns.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openWith",
+				"title": "%command.openWith.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.revealInExplorer",
+				"title": "%command.revealInExplorer.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.toggleMarkdownToolbar",
+				"title": "%command.toggleMarkdownToolbar.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.showMarkdownFormatMenu",
+				"title": "%command.showMarkdownFormatMenu.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.applyMarkdownFormat",
+				"title": "%command.applyMarkdownFormat.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.showFileTrackingStats",
+				"title": "%command.showFileTrackingStats.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.fileTracking.repairPathKeys",
+				"title": "%command.fileTracking.repairPathKeys.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.timeStats.repairSummary",
+				"title": "%command.timeStats.repairSummary.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.cleanupMissingFiles",
+				"title": "%command.cleanupMissingFiles.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.exportTrackingData",
+				"title": "%command.exportTrackingData.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.fileTracker.openShardForFile",
+				"title": "%command.fileTracker.openShardForFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.gcFileTracking",
+				"title": "%command.gcFileTracking.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.createNewFile",
+				"title": "%command.wordCount.createNewFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.createNewFolder",
+				"title": "%command.wordCount.createNewFolder.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.insertFileAbove",
+				"title": "%command.wordCount.insertFileAbove.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.insertFileBelow",
+				"title": "%command.wordCount.insertFileBelow.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.insertFolderAbove",
+				"title": "%command.wordCount.insertFolderAbove.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.insertFolderBelow",
+				"title": "%command.wordCount.insertFolderBelow.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.open",
+				"title": "%command.wordCount.open.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.revealInOS",
+				"title": "%command.wordCount.revealInOS.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.rename",
+				"title": "%command.wordCount.rename.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.delete",
+				"title": "%command.wordCount.delete.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.exportTypst",
+				"title": "导出：使用Typst模板"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.toggleManualOrdering",
+				"title": "%command.wordCount.toggleManualOrdering.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.enableManualOrdering",
+				"title": "%command.wordCount.enableManualOrdering.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.disableManualOrdering",
+				"title": "%command.wordCount.disableManualOrdering.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.generateIndexFromName",
+				"title": "%command.wordCount.generateIndexFromName.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.clearIndex",
+				"title": "%command.wordCount.clearIndex.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.setIndexManual",
+				"title": "%command.wordCount.setIndexManual.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.bulkGenerateIndices",
+				"title": "%command.wordCount.bulkGenerateIndices.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.forceRecountAll",
+				"title": "%command.wordCount.forceRecountAll.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.forceRecountHere",
+				"title": "%command.wordCount.forceRecountHere.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.rescanResourceFilesInFolder",
+				"title": "%command.wordCount.rescanResourceFilesInFolder.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.copy",
+				"title": "%command.wordCount.copy.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.cut",
+				"title": "%command.wordCount.cut.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wordCount.paste",
+				"title": "%command.wordCount.paste.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.package.copy",
+				"title": "%command.package.copy.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.package.cut",
+				"title": "%command.package.cut.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.package.paste",
+				"title": "%command.package.paste.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.package.rescanExternalFolders",
+				"title": "%command.package.rescanExternalFolders.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.package.showExternalScanReport",
+				"title": "%command.package.showExternalScanReport.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.setupGitIdentity",
+				"title": "%command.setupGitIdentity.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.openSetupWizard",
+				"title": "%command.openSetupWizard.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wizard.checkGit",
+				"title": "%command.wizard.checkGit.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wizard.openGitDownload",
+				"title": "%command.wizard.openGitDownload.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wizard.checkGitUser",
+				"title": "%command.wizard.checkGitUser.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.wizard.configureGitUser",
+				"title": "%command.wizard.configureGitUser.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.testGitDownloadLink",
+				"title": "%command.testGitDownloadLink.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.simulateNoGit",
+				"title": "%command.simulateNoGit.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.projectInitWizard",
+				"title": "%command.projectInitWizard.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.projectInitWizard.graphical",
+				"title": "打开图形化项目初始化向导",
+				"category": "Andrea Novel Helper",
+				"icon": "$(rocket)"
+			},
+			{
+				"command": "AndreaNovelHelper.showGuide",
+				"title": "打开功能引导",
+				"category": "Andrea Novel Helper",
+				"icon": "$(book)"
+			},
+			{
+				"command": "AndreaNovelHelper.openHello",
+				"title": "打开 ANH Hello 首页",
+				"category": "Andrea Novel Helper",
+				"icon": "$(home)"
+			},
+			{
+				"command": "AndreaNovelHelper.showGuideDoc",
+				"title": "%command.showGuideDoc.title%",
+				"category": "Andrea Novel Helper",
+				"icon": "$(book)"
+			},
+			{
+				"command": "AndreaNovelHelper.generateLookupKeysForCurrentFile",
+				"title": "为当前角色文件生成查询键",
+				"category": "Andrea Novel Helper",
+				"icon": "$(symbol-key)"
+			},
+			{
+				"command": "AndreaNovelHelper.disableWorkspace",
+				"title": "%command.disableWorkspace.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.enableWorkspace",
+				"title": "%command.enableWorkspace.title%"
+			},
+			{
+				"command": "andrea.refreshMaioStatus",
+				"title": "%command.refreshMaioStatus.title%",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.detectTxtRoleFiles",
+				"title": "检测 TXT 角色档案并迁移",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.migrateTxtRoleFile",
+				"title": "迁移 TXT 角色档案",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.typo.scanDocument",
+				"title": "扫描错别字（未扫描段落）",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.typo.rescanDocument",
+				"title": "重新扫描错别字（强制全量）",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.typo.rescanCurrentFile",
+				"title": "重新扫描当前文件错别字",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.typo.stopAllRequests",
+				"title": "强制停止所有错别字扫描请求",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.typo.translateSelection",
+				"title": "翻译选中文本（LLM）",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.webdav.manageAccounts",
+				"title": "%command.webdav.manageAccounts.title%"
+			},
+			{
+				"command": "andrea.webdav.syncNow",
+				"title": "%command.webdav.syncNow.title%"
+			},
+			{
+				"command": "andrea.webdav.openPanel",
+				"title": "%command.webdav.openPanel.title%"
+			},
+			{
+				"command": "andrea.webdav.refreshFiles",
+				"title": "%command.webdav.refreshFiles.title%"
+			},
+			{
+				"command": "andrea.webdav.openFile",
+				"title": "%command.webdav.openFile.title%"
+			},
+			{
+				"command": "andrea.webdav.uploadFile",
+				"title": "%command.webdav.uploadFile.title%"
+			},
+			{
+				"command": "andrea.webdav.deleteFile",
+				"title": "%command.webdav.deleteFile.title%"
+			},
+			{
+				"command": "andrea.webdav.createFolder",
+				"title": "%command.webdav.createFolder.title%"
+			},
+			{
+				"command": "andrea.webdav.renameFile",
+				"title": "%command.webdav.renameFile.title%"
+			},
+			{
+				"command": "andrea.webdav.copyFile",
+				"title": "%command.webdav.copyFile.title%"
+			},
+			{
+				"command": "AndreaNovelHelper.database.switchBackend",
+				"title": "切换数据库后端",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.database.migrate",
+				"title": "运行数据库迁移",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.database.showStatus",
+				"title": "查看数据库状态",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.database.healthCheck",
+				"title": "数据库健康检查",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.database.optimize",
+				"title": "优化数据库",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.database.compare",
+				"title": "比较数据库后端数据",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.roleUsage.rebuildIndex",
+				"title": "Andrea Novel Helper: 重新索引角色引用",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.roleUsage.clearIndex",
+				"title": "Andrea Novel Helper: 清除角色引用索引",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.fileTracking.cleanAbsolutePaths",
+				"title": "Andrea Novel Helper: 清理文件追踪数据库中的绝对路径",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.openRoleHeatmap",
+				"title": "打开角色引用热力图",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.circlePacking.getRoleReferenceData",
+				"title": "获取角色引用数据",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.circlePacking.getFileTimelineData",
+				"title": "获取文件时间线数据",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.circlePacking.getCompleteDataset",
+				"title": "获取完整数据集",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.circlePacking.exportToJson",
+				"title": "导出 Circle Packing 数据到 JSON",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "AndreaNovelHelper.circlePacking.debugPrintStats",
+				"title": "输出 Circle Packing 数据统计",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.scripts.refresh",
+				"title": "刷新脚本列表",
+				"icon": "$(refresh)"
+			},
+			{
+				"command": "andrea.scripts.open",
+				"title": "打开脚本"
+			},
+			{
+				"command": "andrea.scripts.run",
+				"title": "运行脚本",
+				"icon": "$(run)"
+			},
+			{
+				"command": "andrea.scripts.newScript",
+				"title": "新建脚本",
+				"icon": "$(new-file)"
+			},
+			{
+				"command": "andrea.scripts.deleteScript",
+				"title": "删除脚本"
+			},
+			{
+				"command": "andrea.scripts.renameScript",
+				"title": "重命名脚本"
+			},
+			{
+				"command": "andrea.scripts.openFolder",
+				"title": "打开脚本文件夹",
+				"icon": "$(folder-opened)"
+			},
+			{
+				"command": "andrea-novel-helper.generateRandomNames",
+				"title": "生成随机名字",
+				"category": "Andrea Novel Helper",
+				"icon": "$(symbol-misc)"
+			},
+			{
+				"command": "andrea-novel-helper.quickGenerateName",
+				"title": "快速生成名字",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea-novel-helper.showNameGeneratorStats",
+				"title": "显示名字生成统计",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea-novel-helper.generateRandomCharacter",
+				"title": "随机生成角色",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea-novel-helper.generateStepByStepCharacter",
+				"title": "随机分步生成角色（姓氏+名字）",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.autoScroll.toggle",
+				"title": "切换自动滚动",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.autoScroll.setRatio",
+				"title": "设置自动滚动比例",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.autoScroll.scrollToEnd",
+				"title": "滚动到文档末尾",
+				"category": "Andrea Novel Helper"
+			},
+			{
+				"command": "andrea.openWhatsNew",
+				"title": "打开 What's New",
+				"category": "Andrea Novel Helper",
+				"icon": "$(rocket)"
+			},
+			{
+				"command": "andrea.copilot.exportMcpStdioScript",
+				"title": "释放 MCP stdio 代理桥脚本",
+				"category": "Andrea Novel Helper",
+				"icon": "$(terminal)"
+			}
+		],
+		"walkthroughs": [
+			{
+				"id": "andreaNovelHelper.setup",
+				"title": "%walkthrough.andrea.setup.title%",
+				"description": "%walkthrough.andrea.setup.description%",
+				"steps": [
+					{
+						"id": "anh.step.open",
+						"title": "%walkthrough.anh.step.open.title%",
+						"description": "%walkthrough.anh.step.open.description%",
+						"media": {
+							"markdown": "media/walkthrough/step0_intro.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.openSetupWizard"
+						]
+					},
+					{
+						"id": "anh.step.checkGit",
+						"title": "%walkthrough.anh.step.checkGit.title%",
+						"description": "%walkthrough.anh.step.checkGit.description%",
+						"media": {
+							"markdown": "media/walkthrough/step1_checkGit.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.wizard.checkGit"
+						]
+					},
+					{
+						"id": "anh.step.installGit",
+						"title": "%walkthrough.anh.step.installGit.title%",
+						"description": "%walkthrough.anh.step.installGit.description%",
+						"media": {
+							"markdown": "media/walkthrough/step2_installGit.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.wizard.openGitDownload"
+						]
+					},
+					{
+						"id": "anh.step.checkUser",
+						"title": "%walkthrough.anh.step.checkUser.title%",
+						"description": "%walkthrough.anh.step.checkUser.description%",
+						"media": {
+							"markdown": "media/walkthrough/step3_checkUser.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.wizard.checkGitUser"
+						]
+					},
+					{
+						"id": "anh.step.configureUser",
+						"title": "%walkthrough.anh.step.configureUser.title%",
+						"description": "%walkthrough.anh.step.configureUser.description%",
+						"media": {
+							"markdown": "media/walkthrough/step4_configUser.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.wizard.configureGitUser"
+						]
+					},
+					{
+						"id": "anh.step.recheck",
+						"title": "%walkthrough.anh.step.recheck.title%",
+						"description": "%walkthrough.anh.step.recheck.description%",
+						"media": {
+							"markdown": "media/walkthrough/step5_recheck.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.wizard.checkGitUser"
+						]
+					},
+					{
+						"id": "anh.step.vscodeSidebar",
+						"title": "%walkthrough.anh.step.vscodeSidebar.title%",
+						"description": "%walkthrough.anh.step.vscodeSidebar.description%",
+						"media": {
+							"markdown": "media/walkthrough/step6_vscodeSidebar.md"
+						},
+						"completionEvents": [
+							"onCommand:workbench.view.explorer"
+						]
+					},
+					{
+						"id": "anh.step.anhFeatures",
+						"title": "%walkthrough.anh.step.anhFeatures.title%",
+						"description": "%walkthrough.anh.step.anhFeatures.description%",
+						"media": {
+							"markdown": "media/walkthrough/step7_anhFeatures.md"
+						},
+						"completionEvents": [
+							"onCommand:AndreaNovelHelper.showGuideDoc"
+						]
+					},
+					{
+						"id": "anh.step.finish",
+						"title": "%walkthrough.anh.step.finish.title%",
+						"description": "%walkthrough.anh.step.finish.description%",
+						"media": {
+							"markdown": "media/walkthrough/step8_finish.md"
+						}
+					}
+				]
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "%config.title%",
+			"properties": {
+				"AndreaNovelHelper.typo.applyPartialDecorationsImmediately": {
+					"anhName": "即时错别字高亮",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "在LLM分段结果(partial)阶段是否立刻应用错别字高亮（默认否，仅在最终结果阶段应用，避免\"瞬间出现又消失\"的闪烁）"
+				},
+				"AndreaNovelHelper.writingDashboard.widget.showHeader": {
+					"anhName": "创作工作台独立组件显示顶栏",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "独立打开创作工作台组件时是否显示顶部标题栏和“打开工作台”按钮。关闭后组件内容会占满整个 Webview。"
+				},
+				"AndreaNovelHelper.typo.suppressRolesMode": {
+					"anhName": "角色抑制模式",
+					"type": "string",
+					"enum": [
+						"none",
+						"roleNameExact",
+						"regexContain",
+						"nonSensitiveIntersect"
+					],
+					"default": "roleNameExact",
+					"markdownDescription": "错别字标记的角色抑制模式：none（不抑制）；roleNameExact（仅当错字文本与某角色名完全相等时抑制，忽略正则角色）；regexContain（仅当被正则表达式角色完全包含整段时抑制）；nonSensitiveIntersect（旧版：与任意非敏感角色相交则抑制）"
+				},
+				"AndreaNovelHelper.translate.targets": {
+					"anhName": "翻译目标语言列表",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"中文",
+						"英文",
+						"日语",
+						"德语",
+						"法语",
+						"韩语",
+						"繁体中文",
+						"拉丁语",
+						"希腊语"
+					],
+					"markdownDescription": "右键翻译的可选目标语言列表"
+				},
+				"AndreaNovelHelper.translate.defaultTarget": {
+					"anhName": "默认翻译目标语言",
+					"type": "string",
+					"enum": [
+						"中文",
+						"英文",
+						"日语",
+						"德语",
+						"法语",
+						"韩语",
+						"繁体中文",
+						"拉丁语",
+						"希腊语"
+					],
+					"default": "中文",
+					"markdownDescription": "翻译默认目标语言（与可选列表配合使用）"
+				},
+				"AndreaNovelHelper.translate.alwaysUseDefaultTarget": {
+					"anhName": "跳过语言选择",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "跳过语言选择，直接使用默认目标语言"
+				},
+				"AndreaNovelHelper.translate.defaultAction": {
+					"anhName": "翻译结果处理方式",
+					"type": "string",
+					"enum": [
+						"replaceSelection",
+						"openInNewTab",
+						"copyToClipboard"
+					],
+					"default": "replaceSelection",
+					"markdownDescription": "翻译结果默认处理方式：替换选区/新标签页/复制到剪贴板"
+				},
+				"AndreaNovelHelper.translate.alwaysUseDefaultAction": {
+					"anhName": "跳过处理方式选择",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "跳过处理方式选择，直接使用默认处理方式"
+				},
+				"AndreaNovelHelper.comments.authorName": {
+					"anhName": "批注作者名",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "批注作者显示名（留空则使用系统用户名）"
+				},
+				"AndreaNovelHelper.comments.showInOverviewRuler": {
+					"anhName": "显示概览标尺",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "在编辑器右侧概览标尺中显示批注范围标记"
+				},
+				"AndreaNovelHelper.comments.style.mode": {
+					"anhName": "批注展示风格",
+					"type": "string",
+					"enum": [
+						"underline",
+						"highlight"
+					],
+					"default": "underline",
+					"markdownDescription": "批注范围展示风格：下划线或高亮背景"
+				},
+				"AndreaNovelHelper.comments.style.underlineStyle": {
+					"anhName": "下划线样式",
+					"type": "string",
+					"enum": [
+						"solid",
+						"wavy",
+						"dotted",
+						"dashed"
+					],
+					"default": "solid",
+					"markdownDescription": "下划线样式"
+				},
+				"AndreaNovelHelper.comments.style.underlineColor": {
+					"anhName": "下划线颜色",
+					"type": "string",
+					"default": "#0e639c",
+					"markdownDescription": "下划线颜色（CSS 颜色）"
+				},
+				"AndreaNovelHelper.comments.style.highlightOffset": {
+					"anhName": "高亮背景强度",
+					"type": "number",
+					"default": 0.06,
+					"minimum": 0,
+					"maximum": 0.5,
+					"markdownDescription": "高亮背景强度：在当前主题背景上叠加的透明度偏移（亮色为黑、暗色为白）"
+				},
+				"AndreaNovelHelper.comments.hoverEnabled": {
+					"anhName": "悬停显示批注",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "鼠标悬停批注范围时显示批注内容"
+				},
+				"AndreaNovelHelper.comments.showGutterInfo": {
+					"anhName": "显示行号图标",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "在有批注的行号区域显示信息图标，便于快速定位（可关闭）"
+				},
+				"AndreaNovelHelper.comments.relink.strict": {
+					"anhName": "严格重定位",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "严格重定位：仅在上下文吻合或距原位置不远时才回钩；否则视为该范围已缺失，不再兜底到段落。"
+				},
+				"AndreaNovelHelper.comments.cleanup.mode": {
+					"anhName": "清理模式",
+					"type": "string",
+					"enum": [
+						"delete-thread",
+						"delete-range",
+						"mark-resolved",
+						"none"
+					],
+					"default": "delete-thread",
+					"markdownDescription": "当所有范围均无法重定位时的处理：delete-thread（软删除整线程），delete-range（仅清空范围），mark-resolved（标记为已解决），none（不处理）。"
+				},
+				"AndreaNovelHelper.allRoles.syncWithDocRoles": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "同步文档角色设置",
+					"markdownDescription": "全部角色是否与\"当前文章角色\"显示设置保持同步。开启则复用 AndreaNovelHelper.docRoles.* 配置；关闭则使用下方 allRoles.* 专属配置。"
+				},
+				"AndreaNovelHelper.allRoles.groupBy": {
+					"type": "string",
+					"enum": [
+						"affiliation",
+						"type",
+						"none"
+					],
+					"default": "affiliation",
+					"anhName": "分组依据",
+					"markdownDescription": "全部角色的分组依据：affiliation / type / none"
+				},
+				"AndreaNovelHelper.allRoles.respectAffiliation": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "遵循角色归属",
+					"markdownDescription": "是否遵循角色归属字段"
+				},
+				"AndreaNovelHelper.allRoles.respectType": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "遵循角色类型",
+					"markdownDescription": "是否遵循角色类型字段"
+				},
+				"AndreaNovelHelper.allRoles.primaryGroup": {
+					"type": "string",
+					"enum": [
+						"affiliation",
+						"type"
+					],
+					"default": "affiliation",
+					"anhName": "首要分组",
+					"markdownDescription": "第一级别分组（归属优先/类型优先）"
+				},
+				"AndreaNovelHelper.allRoles.typeOrder": {
+					"type": "array",
+					"default": [
+						"主角",
+						"主要角色",
+						"反派",
+						"配角",
+						"联动角色",
+						"词汇",
+						"敏感词",
+						"正则表达式",
+						"unknown"
+					],
+					"items": {
+						"type": "string"
+					},
+					"anhName": "角色类型排序",
+					"markdownDescription": "全部角色视图中的角色类型排序。列表靠前的类型会优先显示；未列出的类型会排在后面并继续按名称自然排序。开启“同步文档角色设置”时，全部角色会复用当前文章角色的排序。"
+				},
+				"AndreaNovelHelper.allRoles.customGroups": {
+					"anhName": "自定义分组规则",
+					"type": "array",
+					"default": [
+						{
+							"name": "词汇敏感词",
+							"matchType": "type",
+							"patterns": [
+								"词汇",
+								"敏感词",
+								"正则表达式"
+							]
+						},
+						{
+							"name": "主要角色",
+							"matchType": "type",
+							"patterns": [
+								"主角",
+								"重要",
+								"主要"
+							]
+						},
+						{
+							"name": "配角",
+							"matchType": "type",
+							"patterns": [
+								"配角",
+								"次要",
+								"其他"
+							]
+						}
+					],
+					"items": {
+						"type": "object",
+						"properties": {
+							"name": {
+								"type": "string"
+							},
+							"matchType": {
+								"type": "string",
+								"enum": [
+									"affiliation",
+									"type"
+								]
+							},
+							"patterns": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							}
+						},
+						"required": [
+							"name",
+							"matchType",
+							"patterns"
+						]
+					},
+					"markdownDescription": "全部角色的自定义分组规则"
+				},
+				"AndreaNovelHelper.allRoles.useCustomGroups": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "启用自定义分组",
+					"markdownDescription": "是否启用全部角色的自定义分组规则"
+				},
+				"AndreaNovelHelper.wordCount.referenceVisibleExtensions": {
+					"anhName": "参考文件扩展名",
+					"type": "array",
+					"default": [
+						"tjson5",
+						"png",
+						"jpg",
+						"jpeg",
+						"gif",
+						"bmp",
+						"svg",
+						"webp",
+						"tiff",
+						"ico",
+						"pdf",
+						"doc",
+						"docx",
+						"docm",
+						"dotx",
+						"dotm",
+						"xls",
+						"xlsx",
+						"xlsm",
+						"xltx",
+						"xltm",
+						"xlsb",
+						"csv",
+						"ods",
+						"odt",
+						"ppt",
+						"pptx",
+						"pptm",
+						"potx",
+						"potm",
+						"pps",
+						"ppsx",
+						"ppsm",
+						"odt",
+						"ods",
+						"odp",
+						"odg",
+						"odf",
+						"rtf",
+						"wps",
+						"et",
+						"dps",
+						"drawio",
+						"dio",
+						"vsdx",
+						"vsd",
+						"vssx",
+						"vstx",
+						"lucidchart",
+						"mmd",
+						"plantuml",
+						"puml",
+						"mindnode",
+						"xmind",
+						"mm",
+						"freemind"
+					],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "在字数统计树中显示为参考资料但不计入统计的文件扩展名列表。默认包含常见图片、PDF、Word/Excel/PowerPoint 等。"
+				},
+				"AndreaNovelHelper.docRoles.groupBy": {
+					"type": "string",
+					"enum": [
+						"affiliation",
+						"type",
+						"none"
+					],
+					"default": "affiliation",
+					"anhName": "分组依据",
+					"markdownDescription": "当前文章角色的分组依据：**affiliation** (归属)、**type** (类型) 或 **none** (不分组)"
+				},
+				"AndreaNovelHelper.docRoles.respectAffiliation": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "遵循角色归属",
+					"markdownDescription": "是否遵循角色的归属字段进行分组显示"
+				},
+				"AndreaNovelHelper.docRoles.respectType": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "遵循角色类型",
+					"markdownDescription": "是否遵循角色的类型字段进行分组显示"
+				},
+				"AndreaNovelHelper.docRoles.primaryGroup": {
+					"type": "string",
+					"enum": [
+						"affiliation",
+						"type"
+					],
+					"default": "affiliation",
+					"anhName": "首要分组",
+					"markdownDescription": "第一级别分组依据：**affiliation** (归属) 或 **type** (类型)"
+				},
+				"AndreaNovelHelper.docRoles.typeOrder": {
+					"type": "array",
+					"default": [
+						"主角",
+						"主要角色",
+						"反派",
+						"配角",
+						"联动角色",
+						"词汇",
+						"敏感词",
+						"正则表达式",
+						"unknown"
+					],
+					"items": {
+						"type": "string"
+					},
+					"anhName": "角色类型排序",
+					"markdownDescription": "当前文章角色视图中的角色类型排序。列表靠前的类型会优先显示；未列出的类型会排在后面并继续按名称自然排序。默认让“主角”显示在“配角”之前。"
+				},
+				"AndreaNovelHelper.docRoles.customGroups": {
+					"anhName": "自定义分组规则",
+					"type": "array",
+					"default": [
+						{
+							"name": "词汇敏感词",
+							"matchType": "type",
+							"patterns": [
+								"词汇",
+								"敏感词",
+								"正则表达式"
+							]
+						},
+						{
+							"name": "主要角色",
+							"matchType": "type",
+							"patterns": [
+								"主角",
+								"重要",
+								"主要"
+							]
+						},
+						{
+							"name": "配角",
+							"matchType": "type",
+							"patterns": [
+								"配角",
+								"次要",
+								"其他"
+							]
+						}
+					],
+					"items": {
+						"type": "object",
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "分组显示名称"
+							},
+							"matchType": {
+								"type": "string",
+								"enum": [
+									"affiliation",
+									"type"
+								],
+								"description": "匹配字段类型"
+							},
+							"patterns": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"description": "匹配模式列表（支持部分匹配）"
+							}
+						},
+						"required": [
+							"name",
+							"matchType",
+							"patterns"
+						]
+					},
+					"markdownDescription": "自定义角色分组规则列表，用于创建第一级别的自定义分组"
+				},
+				"AndreaNovelHelper.docRoles.useCustomGroups": {
+					"anhName": "启用自定义分组",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "是否启用自定义分组规则（优先级高于 groupBy 设置）"
+				},
+				"AndreaNovelHelper.roles.details.showColorOnValue": {
+					"anhName": "显示颜色预览",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "在角色详情的值行上显示颜色预览色块（默认: true）。此设置影响全部角色与当前文章角色视图，除非对应的 allRoles/docRoles 同名设置覆盖。"
+				},
+				"AndreaNovelHelper.roles.display.useRoleSvgIfPresent": {
+					"anhName": "使用角色SVG图标",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "如果角色对象包含 svg 字段，是否优先使用该 svg 作为角色图标（默认: false）。支持 data URI 或相对/绝对路径。"
+				},
+				"AndreaNovelHelper.docRoles.details.showColorOnValue": {
+					"anhName": "显示颜色预览",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "在当前文章角色视图中，在值行上显示颜色预览色块（默认: true）。"
+				},
+				"AndreaNovelHelper.docRoles.display.useRoleSvgIfPresent": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "使用角色SVG图标",
+					"markdownDescription": "在当前文章角色视图中，如果角色对象包含 svg 字段，是否优先使用该 svg 作为角色图标（默认: false）。"
+				},
+				"AndreaNovelHelper.docRoles.display.colorizeRoleName": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "角色名称着色",
+					"markdownDescription": "用角色颜色在名称旁显示色块标记（仅影响名称前的图标，不改变文本颜色）。"
+				},
+				"AndreaNovelHelper.docRoles.inheritExpandedFromPrevious": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "继承展开状态",
+					"markdownDescription": "当切换到一个尚无展开记录的文档时，继承上一个文档的展开集合（仅对两者共有的节点生效）。"
+				},
+				"AndreaNovelHelper.allRoles.display.colorizeRoleName": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "角色名称着色",
+					"markdownDescription": "用角色颜色在名称旁显示色块标记（全部角色视图；当未与 docRoles 同步时生效）。"
+				},
+				"AndreaNovelHelper.package.roleNodes.display.useRoleSvgIfPresent": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "包管理器角色节点使用角色SVG图标",
+					"markdownDescription": "在包管理器的文件子角色节点中，如果角色对象包含 svg 字段，是否优先使用该 svg 作为图标。"
+				},
+				"AndreaNovelHelper.package.roleNodes.display.colorizeRoleName": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "包管理器角色节点名称着色",
+					"markdownDescription": "在包管理器的文件子角色节点中，用角色颜色在名称旁显示色块标记。"
+				},
+				"andrea.typeset.statusBar.compact": {
+					"type": "boolean",
+					"default": false,
+					"scope": "window",
+					"anhName": "状态栏显示模式",
+					"markdownDescription": "版式状态栏显示为**简略模式**（仅显示“版式”）。关闭则显示详细信息（缩进、段距、去尾空格、括号补齐、跳出、切段等）。"
+				},
+				"andrea.typeset.statusBar.alwaysShow": {
+					"anhName": "始终显示版式工具条",
+					"type": "boolean",
+					"default": true,
+					"scope": "window",
+					"markdownDescription": "始终显示版式工具条，无论当前是否为支持的文档类型。"
+				},
+				"andrea.typeset.pairs": {
+					"anhName": "自动补齐括号对",
+					"type": [
+						"array",
+						"string"
+					],
+					"default": [
+						"()",
+						"[]",
+						"{}",
+						"“”",
+						"‘’",
+						"「」",
+						"『』",
+						"《》",
+						"〈〉",
+						"（）"
+					],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.typeset.pairs.markdownDescription%"
+				},
+				"andrea.typeset.enableAutoPairs": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "智慧补齐括号",
+					"description": "%config.typeset.enableAutoPairs.description%"
+				},
+				"andrea.typeset.enableChineseIMEFix": {
+					"anhName": "修复中文输入法",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.typeset.enableChineseIMEFix.description%"
+				},
+				"andrea.typeset.chineseIMEDelay": {
+					"anhName": "中文输入法延迟",
+					"type": "number",
+					"default": 50,
+					"minimum": 0,
+					"maximum": 500,
+					"markdownDescription": "%config.typeset.chineseIMEDelay.description%"
+				},
+				"andrea.typeset.enableSmartEnter": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "智慧切段（Enter）",
+					"description": "%config.typeset.enableSmartEnter.description%"
+				},
+				"andrea.typeset.enableSmartExit": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "智慧跳出括号/引号",
+					"description": "%config.typeset.enableSmartExit.description%"
+				},
+				"andrea.typeset.indentFirstTwoSpaces": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "段首缩进",
+					"description": "%config.typeset.indentFirstTwoSpaces.description%"
+				},
+				"andrea.typeset.blankLinesBetweenParas": {
+					"type": "integer",
+					"default": 1,
+					"minimum": 0,
+					"maximum": 6,
+					"anhName": "段间空行数",
+					"description": "%config.typeset.blankLinesBetweenParas.description%"
+				},
+				"andrea.typeset.addBlanks.sentenceEnders": {
+					"anhName": "句末标点",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"。",
+						"！",
+						"？",
+						"…",
+						"；",
+						"：",
+						"!",
+						"?",
+						";",
+						":",
+						"."
+					],
+					"description": "%config.typeset.addBlanks.sentenceEnders.description%"
+				},
+				"andrea.typeset.addBlanks.trailingClosers": {
+					"anhName": "后置括号",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"'",
+						"\"",
+						"\\'",
+						"\"",
+						"」",
+						"』",
+						"》",
+						"）",
+						"】",
+						"〉",
+						"〕",
+						"〗",
+						"〙",
+						"〛",
+						"〞",
+						"＂",
+						"＇",
+						"｝",
+						"］"
+					],
+					"description": "%config.typeset.addBlanks.trailingClosers.description%"
+				},
+				"andrea.typeset.addBlanks.leadingOpeners": {
+					"anhName": "前导括号列表",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"“",
+						"\"",
+						"『",
+						"「",
+						"（",
+						"(",
+						"《",
+						"〈",
+						"【",
+						"["
+					],
+					"description": "%config.typeset.addBlanks.leadingOpeners.description%"
+				},
+				"andrea.typeset.trimTrailingSpaces": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "去尾空格",
+					"description": "%config.typeset.trimTrailingSpaces.description%"
+				},
+				"AndreaNovelHelper.enableWordSegmentFilter": {
+					"anhName": "启用词汇过滤",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.roles.enableWordSegmentFilter.description%"
+				},
+				"AndreaNovelHelper.wordSegment.autoFilterMaxLength": {
+					"anhName": "自动过滤最大长度",
+					"type": "integer",
+					"default": 1,
+					"minimum": 1,
+					"maximum": 6,
+					"description": "%config.roles.wordSegment.autoFilterMaxLength.description%"
+				},
+				"AndreaNovelHelper.rolesFile": {
+					"anhName": "角色文件路径",
+					"type": "string",
+					"default": "novel-helper/character-gallery.json5",
+					"description": "%config.rolesFile.description%"
+				},
+				"andrea.roleJson5.openWithRoleManager": {
+					"anhName": "使用角色管理器打开",
+					"type": "boolean",
+					"default": true,
+					"description": "是否默认使用角色卡管理器打开 JSON5 角色文件"
+				},
+				"AndreaNovelHelper.roleEditor.localizedKeyLabels": {
+					"anhName": "角色编辑器字段显示名本地化",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "%config.roleEditor.localizedKeyLabels.markdownDescription%"
+				},
+				"AndreaNovelHelper.sensitiveWordsFile": {
+					"anhName": "敏感词文件路径",
+					"type": "string",
+					"default": "novel-helper/sensitive-words.json5",
+					"description": "%config.sensitiveWordsFile.description%"
+				},
+				"AndreaNovelHelper.vocabularyFile": {
+					"anhName": "词汇文件路径",
+					"type": "string",
+					"default": "novel-helper/vocabulary.json5",
+					"description": "%config.vocabularyFile.description%"
+				},
+				"AndreaNovelHelper.regexPatternsFile": {
+					"anhName": "正则模式文件路径",
+					"type": "string",
+					"default": "novel-helper/regex-patterns.json5",
+					"description": "%config.regexPatternsFile.description%"
+				},
+				"AndreaNovelHelper.outlinePath": {
+					"anhName": "大纲路径",
+					"type": "string",
+					"default": "novel-helper/outline",
+					"description": "%config.outlinePath.description%"
+				},
+				"AndreaNovelHelper.rolePriority": {
+					"anhName": "角色合并优先级策略",
+					"type": "object",
+					"default": {
+						"strategy": "loadOrder",
+						"enableFileNamePriority": false,
+						"enableFileTypePriority": false,
+						"enableLocationPriority": false,
+						"fileNamePriority": {
+							"prefixes": {
+								"__": 1000,
+								"!!": 2000,
+								"!!!": 3000,
+								"override_": 1500,
+								"config_": 500
+							},
+							"naturalSort": true
+						},
+						"fileTypePriority": {
+							".md": 1,
+							".json5": 2,
+							".ojson5": 3,
+							".txt": 0
+						},
+						"locationPriority": {
+							"external": 100,
+							"internal": 0
+						},
+						"defaultPriority": 0
+					},
+					"properties": {
+						"strategy": {
+							"type": "string",
+							"enum": [
+								"loadOrder",
+								"custom"
+							],
+							"default": "loadOrder",
+							"description": "%config.rolePriority.strategy.description%"
+						},
+						"enableFileNamePriority": {
+							"type": "boolean",
+							"default": false,
+							"description": "%config.rolePriority.enableFileNamePriority.description%"
+						},
+						"enableFileTypePriority": {
+							"type": "boolean",
+							"default": false,
+							"description": "%config.rolePriority.enableFileTypePriority.description%"
+						},
+						"enableLocationPriority": {
+							"type": "boolean",
+							"default": false,
+							"description": "%config.rolePriority.enableLocationPriority.description%"
+						},
+						"fileNamePriority": {
+							"type": "object",
+							"description": "%config.rolePriority.fileNamePriority.description%",
+							"properties": {
+								"prefixes": {
+									"type": "object",
+									"description": "%config.rolePriority.fileNamePriority.prefixes.description%"
+								},
+								"naturalSort": {
+									"type": "boolean",
+									"default": true,
+									"description": "%config.rolePriority.fileNamePriority.naturalSort.description%"
+								}
+							}
+						},
+						"fileTypePriority": {
+							"type": "object",
+							"description": "%config.rolePriority.fileTypePriority.description%"
+						},
+						"locationPriority": {
+							"type": "object",
+							"properties": {
+								"external": {
+									"type": "number",
+									"default": 100,
+									"description": "%config.rolePriority.locationPriority.external.description%"
+								},
+								"internal": {
+									"type": "number",
+									"default": 0,
+									"description": "%config.rolePriority.locationPriority.internal.description%"
+								}
+							},
+							"description": "%config.rolePriority.locationPriority.description%"
+						},
+						"defaultPriority": {
+							"type": "number",
+							"default": 0,
+							"description": "%config.rolePriority.defaultPriority.description%"
+						}
+					},
+					"description": "%config.rolePriority.description%"
+				},
+				"AndreaNovelHelper.outline.lazyMode": {
+					"anhName": "懒加载模式",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.outline.lazyMode.description%"
+				},
+				"AndreaNovelHelper.minChars": {
+					"anhName": "最少字符数",
+					"type": "number",
+					"default": 1,
+					"minimum": 1,
+					"description": "%config.minChars.description%"
+				},
+				"AndreaNovelHelper.supportedFileTypes": {
+					"anhName": "支持的文件类型",
+					"type": "array",
+					"default": [
+						"markdown",
+						"plaintext",
+						"json5",
+						"csv",
+						"ojson",
+						"ojson5",
+						"rjson",
+						"rjson5",
+						"tjson5"
+					],
+					"description": "%config.supportedFileTypes.description%"
+				},
+				"AndreaNovelHelper.customCharacterFileKeywords": {
+					"anhName": "自定义角色文件关键词",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.customCharacterFileKeywords.description%"
+				},
+				"AndreaNovelHelper.customSensitiveWordsFileKeywords": {
+					"anhName": "自定义敏感词文件关键词",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.customSensitiveWordsFileKeywords.description%"
+				},
+				"AndreaNovelHelper.customVocabularyFileKeywords": {
+					"anhName": "自定义词汇文件关键词",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.customVocabularyFileKeywords.description%"
+				},
+				"AndreaNovelHelper.customRegexFileKeywords": {
+					"anhName": "自定义正则文件关键词",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.customRegexFileKeywords.description%"
+				},
+				"AndreaNovelHelper.workspaceDisabled": {
+					"anhName": "禁用工作区",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.workspaceDisabled.description%"
+				},
+				"AndreaNovelHelper.hello.enabled": {
+					"anhName": "启用 ANH Hello 首页",
+					"type": "boolean",
+					"default": true,
+					"description": "启动时显示 Andrea Novel Helper 的独立新手首页，也可通过命令面板手动打开。"
+				},
+				"AndreaNovelHelper.hello.forceVsCodeManagedDisabling": {
+					"anhName": "Hello 模式只跟随 VS Code 扩展开关",
+					"type": "boolean",
+					"default": true,
+					"description": "启用 Hello 首页时，在运行时绕过 ANH 自己的工作区禁用判断，改为只跟随 VS Code 扩展管理里的启用/禁用状态；不会改写 AndreaNovelHelper.useVsCodeManagedDisabling 原设置。"
+				},
+				"AndreaNovelHelper.useVsCodeManagedDisabling": {
+					"anhName": "完全使用 VSCode 托管的禁用系统",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.useVsCodeManagedDisabling.description%",
+					"markdownDescription": "开启后扩展不再读取 Andrea Novel Helper 自己的“禁用/工作区禁用”配置，只按 VS Code 扩展管理里的启用/禁用状态决定是否运行。适合希望完全通过 VS Code 内置禁用系统控制插件生效范围的场景。"
+				},
+				"AndreaNovelHelper.markdownToolbarEnabled": {
+					"anhName": "启用Markdown工具栏",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.markdownToolbarEnabled.description%"
+				},
+				"AndreaNovelHelper.markdownToolbarHeight": {
+					"anhName": "工具栏高度",
+					"type": "number",
+					"default": 28,
+					"minimum": 20,
+					"maximum": 50,
+					"description": "%config.markdownToolbarHeight.description%"
+				},
+				"AndreaNovelHelper.timeStats.enabledLanguages": {
+					"anhName": "统计启用语言",
+					"type": "array",
+					"default": [
+						"markdown",
+						"plaintext"
+					],
+					"description": "%config.timeStats.enabledLanguages.description%"
+				},
+				"AndreaNovelHelper.hugeFile.thresholdBytes": {
+					"anhName": "超大文件阈值",
+					"type": "number",
+					"default": 51200,
+					"minimum": 1024,
+					"maximum": 10485760,
+					"description": "%config.hugeFile.thresholdBytes.description%"
+				},
+				"AndreaNovelHelper.hugeFile.suppressWarning": {
+					"anhName": "抑制警告",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.hugeFile.suppressWarning.description%"
+				},
+				"AndreaNovelHelper.timeStats.idleThresholdMs": {
+					"anhName": "闲置阈值",
+					"type": "number",
+					"default": 30000,
+					"minimum": 5000,
+					"maximum": 300000,
+					"description": "%config.timeStats.idleThresholdMs.description%"
+				},
+				"AndreaNovelHelper.timeStats.bucketSizeMs": {
+					"anhName": "统计时间桶",
+					"type": "number",
+					"default": 60000,
+					"minimum": 10000,
+					"maximum": 600000,
+					"description": "%config.timeStats.bucketSizeMs.description%"
+				},
+				"AndreaNovelHelper.timeStats.imeDebounceMs": {
+					"anhName": "输入法防抖",
+					"type": "number",
+					"default": 350,
+					"minimum": 100,
+					"maximum": 2000,
+					"description": "%config.timeStats.imeDebounceMs.description%"
+				},
+				"AndreaNovelHelper.timeStats.respectWcignore": {
+					"anhName": "遵循忽略文件",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.timeStats.respectWcignore.description%"
+				},
+				"AndreaNovelHelper.timeStats.exitIdleOn": {
+					"anhName": "退出闲置触发",
+					"type": "string",
+					"default": "text-change",
+					"enum": [
+						"text-change",
+						"window-focus",
+						"editor-change"
+					],
+					"enumDescriptions": [
+						"%config.timeStats.exitIdleOn.textChange%",
+						"%config.timeStats.exitIdleOn.windowFocus%",
+						"%config.timeStats.exitIdleOn.editorChange%"
+					],
+					"description": "%config.timeStats.exitIdleOn.description%"
+				},
+				"AndreaNovelHelper.timeStats.largeFile.thresholdBytes": {
+					"anhName": "大文件阈值",
+					"type": "number",
+					"default": 65536,
+					"minimum": 4096,
+					"description": "%config.timeStats.largeFile.thresholdBytes.description%"
+				},
+				"AndreaNovelHelper.timeStats.largeFile.approximate": {
+					"anhName": "大文件近似统计",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.timeStats.largeFile.approximate.description%"
+				},
+				"AndreaNovelHelper.timeStats.largeFile.accurateEveryChanges": {
+					"anhName": "精确统计变更次数",
+					"type": "number",
+					"default": 80,
+					"minimum": 5,
+					"description": "%config.timeStats.largeFile.accurateEveryChanges.description%"
+				},
+				"AndreaNovelHelper.timeStats.largeFile.accurateEveryMs": {
+					"anhName": "精确统计时间间隔",
+					"type": "number",
+					"default": 60000,
+					"minimum": 5000,
+					"description": "%config.timeStats.largeFile.accurateEveryMs.description%"
+				},
+				"AndreaNovelHelper.timeStats.debug": {
+					"anhName": "调试模式",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.timeStats.debug.description%"
+				},
+				"AndreaNovelHelper.timeStats.milestone.enabled": {
+					"anhName": "里程碑启用",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.timeStats.milestone.enabled.description%"
+				},
+				"AndreaNovelHelper.timeStats.milestone.targets": {
+					"anhName": "里程碑目标",
+					"type": "array",
+					"default": [
+						1000,
+						2000,
+						5000,
+						10000,
+						20000,
+						50000,
+						100000
+					],
+					"items": {
+						"type": "number",
+						"minimum": 1
+					},
+					"description": "%config.timeStats.milestone.targets.description%"
+				},
+				"AndreaNovelHelper.timeStats.milestone.notificationType": {
+					"anhName": "里程碑通知类型",
+					"type": "string",
+					"default": "information",
+					"enum": [
+						"information",
+						"modal"
+					],
+					"enumDescriptions": [
+						"%config.timeStats.milestone.notificationType.information%",
+						"%config.timeStats.milestone.notificationType.modal%"
+					],
+					"description": "%config.timeStats.milestone.notificationType.description%"
+				},
+				"AndreaNovelHelper.timeStats.typoDelay.enabled": {
+					"anhName": "错别字延迟启用",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用变更时间窗口机制：在连续编辑期间延迟发送错别字请求，窗口结束后统一触发。"
+				},
+				"AndreaNovelHelper.timeStats.typoDelay.windowMs": {
+					"anhName": "错别字延迟窗口",
+					"type": "number",
+					"default": 5000,
+					"minimum": 100,
+					"maximum": 1000000,
+					"markdownDescription": "变更时间窗口时长（毫秒）。窗口内的连续变更将合并为一次错别字请求。"
+				},
+				"AndreaNovelHelper.wordCount.largeFileThreshold": {
+					"anhName": "大文件阈值",
+					"type": "number",
+					"default": 51200,
+					"minimum": 1024,
+					"description": "%config.wordCount.largeFileThreshold.description%"
+				},
+				"AndreaNovelHelper.wordCount.largeFileAvgBytesPerChar": {
+					"anhName": "大文件平均字节数",
+					"type": "number",
+					"default": 3,
+					"minimum": 0.5,
+					"maximum": 10,
+					"description": "%config.wordCount.largeFileAvgBytesPerChar.description%"
+				},
+				"AndreaNovelHelper.timeStats.persistReadOnlySessions": {
+					"anhName": "只读会话持久化",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.timeStats.persistReadOnlySessions.description%"
+				},
+				"AndreaNovelHelper.timeStats.statusBar.alignment": {
+					"anhName": "状态栏对齐",
+					"type": "string",
+					"default": "left",
+					"enum": [
+						"left",
+						"right"
+					],
+					"enumDescriptions": [
+						"%config.timeStats.statusBar.alignment.left%",
+						"%config.timeStats.statusBar.alignment.right%"
+					],
+					"description": "%config.timeStats.statusBar.alignment.description%"
+				},
+				"AndreaNovelHelper.timeStats.statusBar.priority": {
+					"anhName": "状态栏优先级",
+					"type": "number",
+					"default": 1,
+					"minimum": -1000,
+					"maximum": 1000,
+					"description": "%config.timeStats.statusBar.priority.description%"
+				},
+				"AndreaNovelHelper.timeStats.includePaste": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "粘贴计入统计",
+					"markdownDescription": "是否将复制粘贴文本统一计入统计：包括速度（字/分钟、字/小时）与新增/净增字符。默认关闭，仅统计实际书写增量。"
+				},
+				"AndreaNovelHelper.timeStats.includePasteInSpeed": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "粘贴计入速度",
+					"markdownDescription": "是否将复制粘贴的文本计入速度统计（字/分钟、字/小时）。默认不计入，仅统计实际书写增量。"
+				},
+				"AndreaNovelHelper.timeStats.includePasteInAddedCounters": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "粘贴计入新增",
+					"markdownDescription": "是否将复制粘贴的文本计入“新增/净增”字符统计。默认计入；关闭后仅统计非粘贴产生的新增字符。"
+				},
+				"AndreaNovelHelper.timeStats.pasteThresholdChars": {
+					"type": "number",
+					"default": 32,
+					"minimum": 1,
+					"maximum": 100000,
+					"anhName": "粘贴判定阈值",
+					"markdownDescription": "粘贴判定阈值（字符数）。当一次变更新增字符数 ≥ 该值或包含换行时，视为粘贴。"
+				},
+				"AndreaNovelHelper.fileTracker.respectWcignore": {
+					"anhName": "遵循忽略文件",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.fileTracker.respectWcignore.description%"
+				},
+				"AndreaNovelHelper.fileTracker.respectGitignore": {
+					"anhName": "遵循 Git 忽略",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.fileTracker.respectGitignore.description%"
+				},
+				"AndreaNovelHelper.fileTracker.trustCallerFilters": {
+					"anhName": "信任调用方过滤器",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.fileTracker.trustCallerFilters.description%"
+				},
+				"AndreaNovelHelper.fileTracker.writeLegacySnapshot": {
+					"anhName": "写入旧版快照",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.fileTracker.writeLegacySnapshot.description%"
+				},
+				"AndreaNovelHelper.fileTracker.enableVerboseLogging": {
+					"anhName": "启用详细日志",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.fileTracker.enableVerboseLogging.description%"
+				},
+				"AndreaNovelHelper.wordCount.order.showIndexInLabel": {
+					"anhName": "显示索引",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.wordCount.order.showIndexInLabel.description%"
+				},
+				"AndreaNovelHelper.wordCount.order.step": {
+					"anhName": "索引步长",
+					"type": "number",
+					"default": 10,
+					"minimum": 1,
+					"description": "%config.wordCount.order.step.description%"
+				},
+				"AndreaNovelHelper.wordCount.order.padWidth": {
+					"anhName": "索引宽度",
+					"type": "number",
+					"default": 3,
+					"minimum": 0,
+					"description": "%config.wordCount.order.padWidth.description%"
+				},
+				"AndreaNovelHelper.wordCount.order.autoResequence": {
+					"anhName": "自动重排序",
+					"type": "boolean",
+					"default": true,
+					"description": "%config.wordCount.order.autoResequence.description%"
+				},
+				"AndreaNovelHelper.wordCount.displayFormat": {
+					"anhName": "显示格式",
+					"type": "string",
+					"default": "wan",
+					"enum": [
+						"raw",
+						"wan",
+						"k",
+						"qian"
+					],
+					"enumDescriptions": [
+						"%config.wordCount.displayFormat.raw%",
+						"%config.wordCount.displayFormat.wan%",
+						"%config.wordCount.displayFormat.k%",
+						"%config.wordCount.displayFormat.qian%"
+					],
+					"description": "%config.wordCount.displayFormat.description%"
+				},
+				"AndreaNovelHelper.wordCount.debug": {
+					"anhName": "调试模式",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.wordCount.debug.description%"
+				},
+				"AndreaNovelHelper.wordCount.respectGitignore": {
+					"anhName": "遵循Git忽略",
+					"type": "boolean",
+					"default": true,
+					"description": "写作资源管理器是否遵循 .gitignore（默认开启）。关闭后仅依据 .wcignore（若下项开启）或完全不依据忽略文件。"
+				},
+				"AndreaNovelHelper.wordCount.respectWcignore": {
+					"anhName": "遵循字数忽略",
+					"type": "boolean",
+					"default": true,
+					"description": "写作资源管理器是否遵循 .wcignore（默认开启）。关闭后将不从 .wcignore 读取忽略规则。"
+				},
+				"AndreaNovelHelper.wordCount.primaryUnit": {
+					"type": "string",
+					"default": "excludePunct",
+					"enum": [
+						"excludePunct",
+						"includePunct",
+						"nonWSNoPunct"
+					],
+					"enumDescriptions": [
+						"词计（CJK 字符 + 英文单词）",
+						"含标点（非空白字符）",
+						"不含标点（非空白且排除标点）"
+					],
+					"anhName": "字数单位",
+					"markdownDescription": "字数统计首要显示单位：\n- **excludePunct**：词计（`CJK 字符 + 英文单词`）\n- **includePunct**：含标点（`非空白字符`）\n- **nonWSNoPunct**：不含标点（`非空白且排除标点`）"
+				},
+				"AndreaNovelHelper.wordCount.statusBar.speedUnit": {
+					"type": "string",
+					"default": "cpm",
+					"enum": [
+						"cpm",
+						"cph"
+					],
+					"enumDescriptions": [
+						"字/分钟",
+						"字/小时"
+					],
+					"anhName": "速度单位",
+					"markdownDescription": "字数统计状态栏速度单位：\n- **cpm**：字/分钟\n- **cph**：字/小时"
+				},
+				"AndreaNovelHelper.wordCount.statusBar.mode": {
+					"type": "string",
+					"default": "detailed",
+					"enum": [
+						"detailed",
+						"semi",
+						"compact"
+					],
+					"enumDescriptions": [
+						"详细：显示用时、字数与速度",
+						"半精简：显示字数与当前速度",
+						"精简：仅显示总字数"
+					],
+					"anhName": "状态栏显示模式",
+					"markdownDescription": "字数统计状态栏显示模式：\n- **detailed**：显示用时、字数与速度\n- **semi**：显示字数与当前速度\n- **compact**：仅显示总字数"
+				},
+				"AndreaNovelHelper.wordCount.statusBar.compact": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "状态栏精简模式",
+					"markdownDescription": "字数统计状态栏精简模式：仅显示总计字数；隐藏时间与速度等附加信息。"
+				},
+				"AndreaNovelHelper.wordCount.maxWorkers": {
+					"anhName": "最大工作线程",
+					"type": "number",
+					"default": 0,
+					"minimum": 0,
+					"maximum": 128,
+					"description": "%config.wordCount.maxWorkers.description%"
+				},
+				"AndreaNovelHelper.wordCount.maxWorkersUpperLimit": {
+					"anhName": "最大工作线程上限",
+					"type": "number",
+					"default": 8,
+					"minimum": 1,
+					"maximum": 128,
+					"description": "%config.wordCount.maxWorkersUpperLimit.description%"
+				},
+				"AndreaNovelHelper.wordCount.skipStartupStatCheck": {
+					"anhName": "跳过启动校验",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "⚠️ 危险选项：启用后，字数统计视图在**冷启动扫描文件时将跳过对已有缓存文件的 fs.stat 校验**，直接信任快照 / 文件追踪数据库 / 内存中的字数统计。这样可以显著减少启动时间，但**无法在启动阶段发现第三方软件或外部工具对文件内容的篡改**，也无法保证缓存与文件系统 100% 一致。仅在你确信本地文本文件几乎不会在 VS Code 之外被修改时使用。"
+				},
+				"AndreaNovelHelper.wordCount.parallelStatCheck": {
+					"anhName": "并行校验",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "启用并行批量 fs.stat 校验。开启后，在冷启动 cache-check 阶段将对所有已缓存文件并行执行 fs.stat（而非逐个串行），显著减少校验耗时。适用于文件数量较多且磁盘/文件系统 I/O 性能较好的场景。注意：当 `skipStartupStatCheck` 开启时，此选项无效。"
+				},
+				"AndreaNovelHelper.debug.completionLog": {
+					"anhName": "调试日志",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.debug.completionLog.description%"
+				},
+				"AndreaNovelHelper.debug.roleFileDetection": {
+					"anhName": "角色文件识别调试",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.debug.roleFileDetection.description%"
+				},
+				"AndreaNovelHelper.debug.smartRoleAdder": {
+					"anhName": "角色合并调试",
+					"type": "boolean",
+					"default": false,
+					"description": "%config.debug.smartRoleAdder.description%"
+				},
+				"AndreaNovelHelper.completion.triggerMode": {
+					"anhName": "补全触发模式",
+					"type": "string",
+					"enum": [
+						"loose",
+						"startsWith",
+						"symbolLoose",
+						"symbolStartsWith"
+					],
+					"default": "loose",
+					"enumDescriptions": [
+						"完全触发（名称包含当前前缀即可触发）",
+						"仅首字（仅当名称/别名以当前前缀开头时触发）",
+						"符号+完全触发（仅当前缀前有指定符号且名称包含前缀时触发）",
+						"符号+仅首字（仅当前缀前有指定符号且名称/别名以当前前缀开头时触发）"
+					],
+					"markdownDescription": "%config.completion.triggerMode.description%"
+				},
+				"AndreaNovelHelper.completion.symbolPrefixes": {
+					"anhName": "补全符号前缀",
+					"type": "array",
+					"default": [
+						"@"
+					],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.completion.symbolPrefixes.description%"
+				},
+				"AndreaNovelHelper.lookupKeys.treatPinyinAsAlias": {
+					"anhName": "拼音查询键按别名展示",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.lookupKeys.treatPinyinAsAlias.description%"
+				},
+				"AndreaNovelHelper.lookupKeys.autoGeneratePinyin": {
+					"anhName": "自动生成拼音查询键",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.lookupKeys.autoGeneratePinyin.description%"
+				},
+				"AndreaNovelHelper.lookupKeys.treatRomanizedAsAlias": {
+					"anhName": "罗马字查询键按别名展示",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.lookupKeys.treatRomanizedAsAlias.description%"
+				},
+				"AndreaNovelHelper.lookupKeys.autoGenerateRomanized": {
+					"anhName": "自动生成罗马字查询键",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.lookupKeys.autoGenerateRomanized.description%"
+				},
+				"AndreaNovelHelper.lookupKeys.useLlmRomanization": {
+					"anhName": "罗马字查询键使用 LLM",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "%config.lookupKeys.useLlmRomanization.description%"
+				},
+				"AndreaNovelHelper.defaultRoleLookupKeys": {
+					"anhName": "默认角色索引键",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.defaultRoleLookupKeys.description%"
+				},
+				"AndreaNovelHelper.extendedLookupKeyPrefixes": {
+					"anhName": "扩展索引键前缀",
+					"type": "array",
+					"default": [],
+					"items": {
+						"type": "string"
+					},
+					"markdownDescription": "%config.extendedLookupKeyPrefixes.description%"
+				},
+				"AndreaNovelHelper.completion.segmenterType": {
+					"anhName": "分词器类型",
+					"type": "string",
+					"enum": [
+						"auto",
+						"intl",
+						"jieba"
+					],
+					"default": "auto",
+					"markdownDescription": "自动补全分词器类型：\n- **auto**：智能选择，中文内容较多时自动使用jieba，否则使用Intl.Segmenter\n- **intl**：强制使用浏览器内置的Intl.Segmenter\n- **jieba**：强制使用jieba中文分词器\n\njieba分词器对中文分词更准确，能提供更好的中文输入补全体验。"
+				},
+				"AndreaNovelHelper.decorations.cacheSize": {
+					"anhName": "装饰缓存大小",
+					"type": "number",
+					"default": 5,
+					"minimum": 0,
+					"maximum": 20,
+					"description": "%config.decorations.cacheSize.description%"
+				},
+				"AndreaNovelHelper.roles.details.alwaysExpandable": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "总是可展开",
+					"markdownDescription": "角色属性详情是否总是可展开；开启后所有属性行都能展开为多行显示。"
+				},
+				"AndreaNovelHelper.roles.details.enableWrapping": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "启用角色详情折行",
+					"markdownDescription": "是否在角色属性详情展开后按列宽进行软折行。关闭后长文本保持单行显示；路径、URI、UUID、正则、SVG/图标等字段始终不会按列宽硬折行。"
+				},
+				"AndreaNovelHelper.roles.details.wrapColumn": {
+					"type": "number",
+					"default": 20,
+					"minimum": 5,
+					"maximum": 200,
+					"anhName": "折行宽度",
+					"markdownDescription": "角色属性详情的软折行宽度（列数），用于多行显示的每行最大字符数。"
+				},
+				"AndreaNovelHelper.roles.details.enableRoleExpansion": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "启用角色展开",
+					"markdownDescription": "是否允许角色节点可展开以查看属性详情；关闭后角色节点将不再可展开。"
+				},
+				"AndreaNovelHelper.package.roleNodes.details.showColorOnValue": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "包管理器角色详情显示颜色预览",
+					"markdownDescription": "在包管理器的文件子角色节点详情中，是否在颜色字段值行显示颜色预览色块。"
+				},
+				"AndreaNovelHelper.package.roleNodes.details.alwaysExpandable": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "包管理器角色详情总是可展开",
+					"markdownDescription": "包管理器的文件子角色节点中，角色属性详情是否总是可展开。"
+				},
+				"AndreaNovelHelper.package.roleNodes.details.enableWrapping": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "包管理器角色详情启用折行",
+					"markdownDescription": "是否在包管理器的角色详情展开后按列宽进行软折行。关闭后长文本保持单行显示；路径、URI、UUID、正则、SVG/图标等字段始终不会按列宽硬折行。"
+				},
+				"AndreaNovelHelper.package.roleNodes.details.wrapColumn": {
+					"type": "number",
+					"default": 20,
+					"minimum": 5,
+					"maximum": 200,
+					"anhName": "包管理器角色详情折行宽度",
+					"markdownDescription": "包管理器的文件子角色节点详情在多行显示时的软折行宽度。"
+				},
+				"AndreaNovelHelper.package.roleNodes.details.enableRoleExpansion": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "包管理器启用角色展开",
+					"markdownDescription": "包管理器的文件子角色节点是否允许展开查看属性详情。"
+				},
+				"AndreaNovelHelper.typo.service.baseUrl": {
+					"anhName": "错别字服务地址",
+					"type": "string",
+					"default": "http://127.0.0.1:8001",
+					"markdownDescription": "错别字服务 API 基地址，例如 http://127.0.0.1:8001"
+				},
+				"AndreaNovelHelper.typo.enabled": {
+					"anhName": "启用错别字检查",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用错别字识别与诊断（关闭后不再调用服务、扫描或标注）。"
+				},
+				"AndreaNovelHelper.typo.mode": {
+					"anhName": "错别字检查模式",
+					"type": "string",
+					"enum": [
+						"macro",
+						"llm"
+					],
+					"default": "macro",
+					"markdownDescription": "错别字识别模式：macro 使用 /correct（规则）；llm 使用 /correct/llm（大语言模型）。\n\n⚠️ **数据安全提醒**：使用 llm 模式时，您的文档内容将发送至第三方服务或本地大模型进行处理。请确保您信任所使用的服务提供商，并自行承担数据安全责任。"
+				},
+				"AndreaNovelHelper.typo.autoIdentifyOnOpen": {
+					"anhName": "打开时自动检查",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "打开文档时是否自动进行错别字识别。关闭后需要手动点击重新识别按钮。"
+				},
+				"AndreaNovelHelper.typo.autoScanOnChange": {
+					"anhName": "变更时自动扫描",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "在编辑内容发生变更时是否自动触发错别字扫描。关闭后仅保留手动扫描模式（通过命令或快速设置触发）。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.enabled": {
+					"anhName": "启用客户端大模型",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "使用本地客户端直连大模型进行错别字识别（实验功能，优先于服务端）。\n\n⚠️ **数据安全提醒**：启用此功能后，您的文档内容将通过配置的 API 发送至第三方大模型服务。请确保您信任所使用的服务提供商，并自行承担数据安全和隐私保护责任。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.apiBase": {
+					"anhName": "API基地址",
+					"type": "string",
+					"default": "https://api.deepseek.com/v1",
+					"markdownDescription": "Chat Completions 兼容 API Base（如 https://api.openai.com/v1 或 DeepSeek）。\n\n⚠️ **数据安全提醒**：配置第三方 API 地址时，请确保您信任该服务提供商。您的文档内容将通过此 API 发送进行处理，请自行评估和承担数据安全风险。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.apiKey": {
+					"anhName": "API密钥",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "客户端直连大模型 API Key（请注意安全）。\n\n⚠️ **数据安全提醒**：API Key 将用于访问第三方服务。请妥善保管您的密钥，避免在共享配置或代码中泄露，并定期更换以确保安全。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.model": {
+					"anhName": "模型名称",
+					"type": "string",
+					"default": "deepseek-v3",
+					"markdownDescription": "客户端直连模型名称。\n\n⚠️ **数据安全提醒**：不同模型的服务商可能有不同的数据处理政策。请在使用前查看并了解相应模型提供商的数据使用条款。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.temperature": {
+					"anhName": "温度参数",
+					"type": "number",
+					"default": 0,
+					"minimum": 0,
+					"maximum": 2,
+					"markdownDescription": "客户端直连模型的 temperature。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.enableThinking": {
+					"anhName": "启用思考模式",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用深度思考模型的思考过程（如 GLM-4.6、GLM-4.5、GLM-4.5-air、DeepSeek-R1、Qwen-R 等支持推理的模型）。\n\n🔧 **配置方式**：需要配合 `thinkingProvider` 配置项来指定参数格式。\n\n📋 **支持的供应商预设**：\n- `auto`：自动检测（默认）\n- `glm`：智谱 GLM 系列\n- `deepseek`：DeepSeek 系列\n- `qwen`：通义千问系列\n- `custom`：自定义配置\n\n⚠️ **注意**：思考过程仅在支持相应格式的模型上有效，请根据模型类型选择合适的预设。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.thinkingProvider": {
+					"anhName": "思考提供商",
+					"type": "string",
+					"default": "auto",
+					"enum": [
+						"auto",
+						"glm",
+						"deepseek",
+						"qwen",
+						"custom"
+					],
+					"markdownDescription": "选择思考过程的参数格式预设。\n\n📋 **预设说明**：\n- `auto`：根据模型名称自动选择合适的参数格式\n- `glm`：智谱 GLM 格式 - `\"thinking\": {\"type\": \"enabled|disabled\"}`\n- `deepseek`：DeepSeek 格式 - `\"extra_body\": {\"enable_thinking\": true}`\n- `qwen`：通义千问格式 - `\"reasoning_effort\": \"high|medium\"`\n- `custom`：使用自定义配置（需配置 `customThinking*` 选项）\n\n💡 **建议**：不确定时选择 `auto`，系统会根据模型名称自动匹配。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.customThinkingEnabled": {
+					"anhName": "自定义思考启用",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用自定义 thinking 字段配置。仅当 `thinkingProvider` 设置为 `custom` 时生效。\n\n⚙️ **配置**：启用后，可配置自定义的字段名和启用/禁用值。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.customThinkingEnabledValue": {
+					"anhName": "自定义思考启用值",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "自定义 thinking 字段的启用值。当 `enableThinking` 为 true 时使用此值。\n\n📝 **示例**：如果字段为 `thinking`，启用值为 `true`，则请求中包含 `\"thinking\": true`。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.customThinkingDisabledValue": {
+					"anhName": "自定义思考禁用值",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "自定义 thinking 字段的禁用值。当 `enableThinking` 为 false 时使用此值。\n\n📝 **示例**：如果字段为 `thinking`，禁用值为 `false`，则请求中包含 `\"thinking\": false`。"
+				},
+				"AndreaNovelHelper.typo.clientLLM.qwenThinkingMethod": {
+					"anhName": "通义千问思考方法",
+					"type": "string",
+					"enum": [
+						"parameter",
+						"suffix"
+					],
+					"default": "parameter",
+					"markdownDescription": "通义千问模型的 thinking 控制方法选择。当 `thinkingProvider` 设置为 \"qwen\" 时生效。\n\n- **parameter**（默认）：使用 `extra_body.enable_thinking=False` 参数\n- **suffix**：使用模型名称后缀 `/no_think`\n\n📝 **示例**：\n- parameter 方法：`\"extra_body\": {\"enable_thinking\": false}`\n- suffix 方法：`\"model\": \"qwen2.5-72b-instruct/no_think\"`"
+				},
+				"AndreaNovelHelper.typo.clientLLM.geminiThinkingBudget": {
+					"anhName": "Gemini思考预算",
+					"type": "number",
+					"default": -1,
+					"markdownDescription": "Google Gemini 模型的思考预算配置。当 `thinkingProvider` 设置为 \"gemini\" 时生效。\n\n- **-1**（默认）：动态思考，模型根据任务复杂度自动调整预算\n- **0**：禁用思考功能\n- **正数**：指定具体的思考 token 预算（如 1024）\n\n📝 **模型支持**：\n- **Gemini 2.5 Pro**：动态思考（128-32768），无法禁用\n- **Gemini 2.5 Flash**：动态思考（0-24576），可禁用\n- **Gemini 2.5 Flash-Lite**：无思考（512-24576），可禁用\n\n📝 **示例请求**：\n```json\n{\n  \"extra_body\": {\n    \"thinking_config\": {\n      \"thinking_budget\": 1024,\n      \"include_thoughts\": true\n    }\n  }\n}\n```"
+				},
+				"AndreaNovelHelper.typo.clientLLM.geminiApiFormat": {
+					"anhName": "Gemini API格式",
+					"type": "string",
+					"enum": [
+						"openai",
+						"native"
+					],
+					"default": "openai",
+					"markdownDescription": "Google Gemini 模型的 API 调用格式。当 `thinkingProvider` 设置为 \"gemini\" 时生效。\n\n- **openai**（默认）：使用 OpenAI 兼容的 API 格式，适用于 OpenAI 兼容的代理服务\n- **native**：使用 Gemini 原生 API 格式，直接调用 Google GenerativeAI API\n\n📝 **OpenAI 兼容格式示例**：\n```json\n{\n  \"model\": \"gemini-2.5-flash\",\n  \"messages\": [...],\n  \"reasoning_effort\": \"low\"\n}\n```\n\n📝 **原生 API 格式示例**：\n```json\n{\n  \"contents\": [\n    {\"parts\": [{\"text\": \"...\"}]}\n  ],\n  \"generationConfig\": {\n    \"thinkingConfig\": {\n      \"thinkingBudget\": 1024\n    }\n  }\n}\n```\n\n⚠️ **注意**：使用原生 API 格式时，API Base URL 需要设置为 `https://generativelanguage.googleapis.com/v1beta`"
+				},
+				"AndreaNovelHelper.externalFolder.ignoredDirectories": {
+					"anhName": "外部文件夹忽略目录",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						".git",
+						".vscode",
+						".idea",
+						"node_modules",
+						"dist",
+						"build",
+						"out",
+						".DS_Store",
+						"Thumbs.db"
+					],
+					"markdownDescription": "外部资源目录扫描时忽略的目录列表。扫描器会保留对 `__init__.ojson5` 的兼容识别，同时也会根据标识扩展名与关键字识别目录。\n\n📝 **默认忽略**：\n- 版本控制：`.git`\n- 编辑器配置：`.vscode`, `.idea`\n- 依赖包：`node_modules`\n- 构建输出：`dist`, `build`, `out`\n- 系统文件：`.DS_Store`, `Thumbs.db`\n\n📝 **使用示例**：\n```json\n[\n  \".git\",\n  \".vscode\",\n  \"node_modules\",\n  \"dist\",\n  \"temp\",\n  \"logs\"\n]\n```"
+				},
+				"AndreaNovelHelper.externalFolder.markerKeywords": {
+					"anhName": "外部资源标识关键字",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"character-gallery",
+						"character",
+						"role",
+						"roles",
+						"sensitive-words",
+						"sensitive",
+						"vocabulary",
+						"vocab",
+						"regex-patterns",
+						"regex",
+						"relationship",
+						"relation",
+						"connections",
+						"links",
+						"timeline",
+						"角色",
+						"人物",
+						"敏感词",
+						"词汇",
+						"词庫",
+						"词库",
+						"正则",
+						"正則",
+						"正则表达式",
+						"正則表達式",
+						"关系",
+						"关联",
+						"连接",
+						"联系",
+						"时间线",
+						"時間線"
+					],
+					"markdownDescription": "外部资源目录识别关键字。若文件名命中这些关键字（并且扩展名在支持集合中），其所在目录会被识别为外部资源目录。\n\n⚠️ 同时保留 legacy 支持：目录内包含 `__init__.ojson5` 也会被识别。\n\n📝 **固定扩展名标识（无需关键字）**：`.ojson5`, `.rjson5`, `.ojson`, `.rjson`, `.tjson5`\n\n📝 **关键字扩展名集合**：`.json5`, `.txt`, `.ojson`, `.rjson`, `.rjson5`, `.ojson5`, `.tjson5`\n\n📝 `.md` 不参与关键字匹配；仅当开启下方“MD库名识别”并命中特定库名规则时，才会识别为外部资源标记文件。"
+				},
+				"AndreaNovelHelper.externalFolder.enableMdLibraryNameMarkers": {
+					"anhName": "MD库名识别",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "是否允许将特定命名规则的 `.md` 文件识别为外部资源标记文件。\n\n开启后，仅以下规则会生效：\n- 精确文件名：`character-gallery.md`、`sensitive-words.md`、`vocabulary.md`\n- 后缀规则：`*_character.md`、`*_sensitive.md`、`*_vocabulary.md`（也支持 `-` 连接）\n\n关闭后，`.md` 文件不会被用于外部资源目录标记识别。"
+				},
+				"AndreaNovelHelper.package.dragDefaultAction": {
+					"anhName": "拖拽默认操作",
+					"type": "string",
+					"enum": [
+						"move",
+						"copy",
+						"ask"
+					],
+					"enumDescriptions": [
+						"默认移动（剪切）",
+						"默认复制",
+						"每次询问"
+					],
+					"default": "move",
+					"markdownDescription": "在包管理器中拖拽文件/文件夹时的默认操作。\n\n- **move**：默认移动（删除源文件）\n- **copy**：默认复制（保留源文件）\n- **ask**：每次都询问用户选择"
+				},
+				"AndreaNovelHelper.package.iconStyle": {
+					"anhName": "文件图标样式",
+					"type": "string",
+					"enum": [
+						"auto",
+						"theme",
+						"custom"
+					],
+					"enumDescriptions": [
+						"自动（优先使用主题图标，无匹配时使用自定义图标）",
+						"仅使用主题图标（不替换任何图标）",
+						"使用自定义图标（始终使用内置语义图标）"
+					],
+					"default": "auto",
+					"markdownDescription": "包管理器中资源文件的图标显示方式。\n\n- **auto**（推荐）：优先使用当前图标主题的图标，仅对 `.ojson5`（角色）、`.rjson5`（关系）、`.tjson5`（时间线）等特殊文件使用语义化图标\n- **theme**：完全使用图标主题的默认图标\n- **custom**：始终使用自定义的语义化图标（角色=`person`，关系=`type-hierarchy`，时间线=`git-branch`）"
+				},
+				"AndreaNovelHelper.typo.debug.llmTrace": {
+					"anhName": "LLM调试追踪",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "调试：输出客户端直连大模型的请求与流式响应到 Output（包含提示词与分段输出，谨慎开启）。"
+				},
+				"AndreaNovelHelper.typo.debug.serverTrace": {
+					"anhName": "服务端调试追踪",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "调试：输出服务端 HTTP /correct 与 /correct/llm 的请求/响应概要到 Output。"
+				},
+				"AndreaNovelHelper.typo.persistence.enabled": {
+					"anhName": "启用持久化",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用错别字数据持久化存储。开启后，错别字扫描结果将保存到本地文件，重启后可恢复之前的扫描结果。"
+				},
+				"AndreaNovelHelper.typo.persistence.autoCleanup": {
+					"anhName": "自动清理",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "自动清理过期的错别字数据文件。"
+				},
+				"AndreaNovelHelper.typo.persistence.maxAgeDays": {
+					"anhName": "数据保存天数",
+					"type": "number",
+					"default": 30,
+					"minimum": 1,
+					"maximum": 365,
+					"markdownDescription": "错别字数据文件的最大保存天数，超过此时间的文件将被自动清理。"
+				},
+				"AndreaNovelHelper.typo.debug.compactTrace": {
+					"anhName": "压缩调试输出",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "调试输出是否压缩为单行（合并换行与多余空白）。"
+				},
+				"AndreaNovelHelper.typo.debug.traceMaxLen": {
+					"anhName": "调试输出最大长度",
+					"type": "number",
+					"default": 1200,
+					"minimum": 200,
+					"maximum": 10000,
+					"markdownDescription": "单条调试输出最大长度（字符）。"
+				},
+				"AndreaNovelHelper.typo.llm.model": {
+					"anhName": "服务端LLM模型",
+					"type": "string",
+					"default": "deepseek-v3",
+					"markdownDescription": "LLM 模型（可选）。为空表示由服务端默认。"
+				},
+				"AndreaNovelHelper.typo.llm.apiKey": {
+					"anhName": "服务端API密钥",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "LLM API Key（可选）。为空表示由服务端默认。"
+				},
+				"AndreaNovelHelper.typo.llm.apiBase": {
+					"anhName": "服务端API地址",
+					"type": "string",
+					"default": "",
+					"markdownDescription": "LLM API Base（可选）。为空表示由服务端默认。"
+				},
+				"AndreaNovelHelper.typo.batchSize": {
+					"anhName": "批次大小",
+					"type": "number",
+					"default": 30,
+					"minimum": 1,
+					"maximum": 200,
+					"markdownDescription": "批量调用每次携带的句子数，建议 10-50（macro）/ 5-20（llm）。"
+				},
+				"AndreaNovelHelper.typo.docConcurrency": {
+					"anhName": "文档并发数",
+					"type": "number",
+					"default": 3,
+					"minimum": 1,
+					"maximum": 10,
+					"markdownDescription": "每个文档并发扫描段落的最大请求数（限流，以免阻塞外部服务）。"
+				},
+				"AndreaNovelHelper.typo.docGroupSize": {
+					"anhName": "文档分组大小",
+					"type": "number",
+					"default": 3,
+					"minimum": 1,
+					"maximum": 20,
+					"markdownDescription": "同一文档连续段落的合并扫描组大小（尽可能给大模型更长的上下文）。"
+				},
+				"AndreaNovelHelper.typo.timeoutMs": {
+					"anhName": "超时时间",
+					"type": "number",
+					"default": 30000,
+					"minimum": 1000,
+					"maximum": 300000,
+					"markdownDescription": "调用错别字服务的超时时间（毫秒）。LLM 模式建议 120000。"
+				},
+				"AndreaNovelHelper.typo.enableHighlight": {
+					"anhName": "启用高亮",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "是否为错别字添加标黄背景（诊断之外的视觉装饰）。"
+				},
+				"AndreaNovelHelper.typo.highlightColor": {
+					"anhName": "高亮颜色",
+					"type": "string",
+					"default": "#fff3a3",
+					"markdownDescription": "错别字标黄背景色（CSS 颜色，如 #fff3a3）。"
+				},
+				"AndreaNovelHelper.typo.maxDocs": {
+					"anhName": "最大文档数",
+					"type": "number",
+					"default": 10,
+					"minimum": 1,
+					"maximum": 200,
+					"markdownDescription": "错别字内存数据库最大文档数（LRU 淘汰）。"
+				},
+				"AndreaNovelHelper.typo.keepCacheOnClose": {
+					"anhName": "关闭时保留缓存",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "关闭编辑器后是否保留错别字扫描缓存（由 LRU 控制释放）。关闭则在关闭文档时立即清理缓存。"
+				},
+				"AndreaNovelHelper.typo.warningLevel": {
+					"anhName": "警告级别",
+					"type": "string",
+					"enum": [
+						"error",
+						"warning",
+						"information",
+						"hint"
+					],
+					"default": "warning",
+					"markdownDescription": "错别字诊断的警告级别：error（错误）、warning（警告）、information（信息）、hint（提示）。"
+				},
+				"AndreaNovelHelper.sensitiveWords.warningLevel": {
+					"anhName": "敏感词警告级别",
+					"type": "string",
+					"enum": [
+						"error",
+						"warning",
+						"information",
+						"hint"
+					],
+					"default": "error",
+					"markdownDescription": "敏感词诊断的警告级别：error（错误）、warning（警告）、information（信息）、hint（提示）。"
+				},
+				"AndreaNovelHelper.webdav.sync.strategy": {
+					"anhName": "同步策略",
+					"type": "string",
+					"default": "timestamp",
+					"enum": [
+						"timestamp",
+						"size",
+						"both",
+						"content"
+					],
+					"enumDescriptions": [
+						"基于文件修改时间戳比较（默认）",
+						"基于文件大小比较",
+						"同时比较时间戳和文件大小",
+						"基于文件内容哈希比较（最准确但较慢）"
+					],
+					"markdownDescription": "WebDAV 同步策略：选择如何判断文件是否需要同步。timestamp 基于修改时间，size 基于文件大小，both 同时检查两者，content 基于内容哈希。"
+				},
+				"AndreaNovelHelper.webdav.sync.timeTolerance": {
+					"anhName": "时间容差",
+					"type": "number",
+					"default": 15000,
+					"minimum": 0,
+					"maximum": 60000,
+					"markdownDescription": "时间戳比较的容差（毫秒）。由于网络传输和服务器处理延迟，允许一定的时间差异。设置为 0 表示严格比较。"
+				},
+				"AndreaNovelHelper.webdav.sync.enableSmartComparison": {
+					"anhName": "启用智能比较",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "启用智能比较算法。结合文件大小和修改时间进行更准确的同步判断，减少误同步。"
+				},
+				"AndreaNovelHelper.webdav.sync.ignoredDirectories": {
+					"anhName": "忽略目录",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						".git",
+						"node_modules",
+						".pixi",
+						".venv",
+						"__pycache__",
+						".pytest_cache",
+						".gradle",
+						".mvn",
+						"bin",
+						"obj",
+						".vs",
+						".idea",
+						".next",
+						".nuxt",
+						".cache",
+						".tmp",
+						"tmp",
+						".cargo",
+						"vendor",
+						"coverage",
+						".nyc_output",
+						".tox",
+						".nox",
+						".dart_tool",
+						".pub-cache"
+					],
+					"markdownDescription": "WebDAV 同步时忽略的目录列表。默认忽略版本控制、依赖包、编译缓存等目录。IDE 和编辑器目录（如 .vscode、.idea 等）不会被忽略，以支持跨设备的开发环境同步。"
+				},
+				"AndreaNovelHelper.webdav.sync.ignoredFiles": {
+					"anhName": "忽略文件",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						".DS_Store",
+						"Thumbs.db",
+						"desktop.ini",
+						"*.tmp",
+						"*.temp",
+						"*.log",
+						"*.pid",
+						"*.lock"
+					],
+					"markdownDescription": "WebDAV 同步时忽略的文件模式列表。支持通配符匹配，用于过滤系统文件、临时文件等。"
+				},
+				"AndreaNovelHelper.webdav.sync.ignoreAppDataDirectories": {
+					"anhName": "忽略应用数据目录",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "是否忽略应用程序内部数据目录（如 .anh-fsdb）。启用时不会同步写作统计、文件追踪等内部数据，推荐保持启用以避免数据冲突。"
+				},
+				"AndreaNovelHelper.webdav.sync.showDiffTable": {
+					"anhName": "显示差异表",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "同步完成后是否在输出日志中显示文件差异表。启用后可以查看本次同步涉及的所有文件变更详情。"
+				},
+				"AndreaNovelHelper.webdav.sync.enableMetadataSidecar": {
+					"anhName": "启用元数据缓存文件",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "是否启用缓存文件元数据功能。启用后会为每个文件创建包含详细元数据的缓存文件，提供更丰富的同步信息。"
+				},
+				"AndreaNovelHelper.webdav.sync.metadataSidecarSuffix": {
+					"anhName": "元数据文件后缀",
+					"type": "string",
+					"default": ".anhmeta.json",
+					"markdownDescription": "缓存文件的后缀名。默认为 .anhmeta.json，用于存储文件的元数据信息。"
+				},
+				"AndreaNovelHelper.webdav.sync.skipDatabaseAccess": {
+					"anhName": "跳过数据库访问",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "跳过数据库访问以提升同步速度。启用后缓存数据将不会从文件追踪数据库获取完整信息，显著提升同步性能。"
+				},
+				"AndreaNovelHelper.webdav.sync.autoSync.enabled": {
+					"anhName": "启用自动同步",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "是否启用定时自动同步。启用后将按设定的时间间隔自动执行双向同步。"
+				},
+				"AndreaNovelHelper.webdav.sync.autoSync.intervalMinutes": {
+					"anhName": "自动同步间隔",
+					"type": "number",
+					"default": 30,
+					"minimum": 1,
+					"maximum": 1440,
+					"markdownDescription": "定时同步的时间间隔（分钟）。范围：1-1440分钟（1分钟到24小时）。"
+				},
+				"AndreaNovelHelper.webdav.sync.autoSync.method": {
+					"anhName": "自动同步方式",
+					"type": "string",
+					"enum": [
+						"bidirectional",
+						"upload",
+						"download"
+					],
+					"default": "bidirectional",
+					"markdownDescription": "定时同步的方法。bidirectional: 双向同步（默认），upload: 仅上传本地文件到服务器，download: 仅从服务器下载文件到本地。"
+				},
+				"AndreaNovelHelper.autoGit.enabled": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "启用自动Git",
+					"markdownDescription": "是否启用AutoGit功能。启用后将自动检测Git仓库变更并执行自动提交和同步。"
+				},
+				"AndreaNovelHelper.autoGit.checkIntervalSeconds": {
+					"type": "number",
+					"default": 30,
+					"minimum": 10,
+					"maximum": 300,
+					"anhName": "检查间隔秒数",
+					"markdownDescription": "检查Git HEAD变更的时间间隔（秒）。范围：10-300秒。"
+				},
+				"AndreaNovelHelper.autoGit.commitMessageTemplate": {
+					"type": "string",
+					"default": "Auto commit: {timestamp}",
+					"anhName": "提交消息模板",
+					"markdownDescription": "自动提交的消息模板。可使用变量：{timestamp}（时间戳）、{files}（变更文件数）、{branch}（分支名）。"
+				},
+				"AndreaNovelHelper.autoGit.autoPull": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "自动拉取",
+					"markdownDescription": "检测到远程变更时是否自动拉取。启用后会在检测到远程HEAD变更时自动执行git pull。"
+				},
+				"AndreaNovelHelper.autoGit.autoPush": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "自动推送",
+					"markdownDescription": "本地提交后是否自动推送到远程仓库。启用后会在自动提交后执行git push。"
+				},
+				"AndreaNovelHelper.autoGit.includeUntracked": {
+					"type": "boolean",
+					"default": false,
+					"anhName": "包含未跟踪文件",
+					"markdownDescription": "是否包含未跟踪的文件。启用后会自动添加新文件到Git暂存区。"
+				},
+				"AndreaNovelHelper.autoGit.compactStatus": {
+					"type": "boolean",
+					"default": false,
+					"scope": "window",
+					"anhName": "简洁状态栏",
+					"markdownDescription": "ANH:Sync 状态栏简洁模式：开启时仅显示 'ANH:Sync'，不显示具体的 Git/WebDAV 状态。"
+				},
+				"AndreaNovelHelper.autoGit.excludePatterns": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"*.tmp",
+						"*.log",
+						".DS_Store",
+						"Thumbs.db"
+					],
+					"anhName": "排除模式",
+					"markdownDescription": "自动提交时排除的文件模式列表。支持通配符匹配。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.enabled": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "启用智能标签组锁定",
+					"markdownDescription": "启用智能标签组锁定功能。当分屏仅包含ANH扩展提供的各种窗体（如预览面板、批注管理、双大纲等）时，自动锁定该分屏以避免新窗体在其中打开。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.enableBuiltinTypes": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "启用内置类型",
+					"markdownDescription": "启用内置智能锁定窗体类型。禁用后，只有自定义配置的窗体类型会参与智能锁定。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.excludeRoleEditor": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "排除角色编辑器",
+					"markdownDescription": "排除角色卡编辑器（andrea.roleEditor）参与智能锁定。默认排除，设为false可让角色卡编辑器参与智能锁定。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.excludeDiffEditor": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "排除差异编辑器",
+					"markdownDescription": "排除差异编辑器（vscode.diff-editor）参与智能锁定。默认排除，设为false可让差异编辑器参与智能锁定。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.excludeNotesDiff": {
+					"type": "boolean",
+					"default": true,
+					"anhName": "排除笔记差异",
+					"markdownDescription": "排除Notes差异编辑器（notes.diff）参与智能锁定。默认排除，设为false可让Notes差异编辑器参与智能锁定。"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.customWebviewTypes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"anhName": "自定义WebView类型",
+					"markdownDescription": "自定义参与智能锁定的WebView类型列表。例如：['my-extension.preview', 'another.webview']"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.customEditorTypes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"anhName": "自定义编辑器类型",
+					"markdownDescription": "自定义参与智能锁定的编辑器类型列表。例如：['my-extension.editor', 'another.custom-editor']"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.customUriSchemes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"anhName": "自定义URI方案",
+					"markdownDescription": "自定义参与智能锁定的URI方案列表。例如：['my-scheme', 'another-scheme']"
+				},
+				"AndreaNovelHelper.smartTabGroupLock.customNotebookTypes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"anhName": "自定义笔记本类型",
+					"markdownDescription": "自定义参与智能锁定的笔记本类型列表。例如：['my-notebook', 'another-notebook']"
+				},
+				"AndreaNovelHelper.database.backend": {
+					"anhName": "数据库后端",
+					"type": "string",
+					"enum": [
+						"json",
+						"sqlite"
+					],
+					"default": "json",
+					"markdownDescription": "数据库后端类型：\n- **json**: JSON文件存储（默认，兼容旧版本）\n- **sqlite**: SQLite数据库（推荐，性能更好）\n\n⚠️ 切换后端时会提示运行数据同步"
+				},
+				"AndreaNovelHelper.database.sqlite.enableWAL": {
+					"anhName": "启用WAL模式",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "启用SQLite的WAL（Write-Ahead Logging）模式，提升并发性能"
+				},
+				"AndreaNovelHelper.database.sqlite.cacheSize": {
+					"anhName": "缓存大小",
+					"type": "number",
+					"default": 2560,
+					"minimum": 256,
+					"maximum": 10240,
+					"markdownDescription": "SQLite缓存大小（页数），默认2560页约10MB"
+				},
+				"AndreaNovelHelper.database.sqlite.enableMmap": {
+					"anhName": "启用内存映射",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "启用SQLite的内存映射IO，提升读取性能"
+				},
+				"AndreaNovelHelper.database.sqlite.initQueueTimeoutMs": {
+					"anhName": "初始化队列等待时长",
+					"type": "number",
+					"default": 15000,
+					"minimum": 1000,
+					"maximum": 120000,
+					"markdownDescription": "SQLite 后端初始化时，文件追踪写操作在内存队列中等待的最长时间（毫秒）。超过该时长后，会临时回退到 JSON 分片持久化以避免继续堆积。"
+				},
+				"AndreaNovelHelper.database.autoMigrate": {
+					"anhName": "自动迁移",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "切换数据库后端时自动运行数据迁移（否则需要手动运行迁移命令）"
+				},
+				"AndreaNovelHelper.startupSnapshot.enabled": {
+					"anhName": "启用启动快照",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "%config.startupSnapshot.enabled.description%"
+				},
+				"AndreaNovelHelper.startupSnapshot.deleteOnDisable": {
+					"anhName": "禁用时删除",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "%config.startupSnapshot.deleteOnDisable.description%"
+				},
+				"AndreaNovelHelper.startupSnapshot.showNotification": {
+					"anhName": "显示通知",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "%config.startupSnapshot.showNotification.description%"
+				},
+				"andrea.typst.cliPath": {
+					"anhName": "CLI路径",
+					"type": "string",
+					"default": "typst",
+					"description": "Typst CLI 可执行路径（留空使用 PATH）"
+				},
+				"andrea.typst.templatesDir": {
+					"anhName": "模板目录",
+					"type": "string",
+					"default": "${workspaceFolder}/templates/typst",
+					"description": "扩展外置模板默认目录"
+				},
+				"andrea.typst.externalTemplatesDir": {
+					"anhName": "外部模板目录",
+					"type": "string",
+					"default": "${workspaceFolder}/novel-helper/templates/typst",
+					"description": "项目 novel-helper 目录下模板路径"
+				},
+				"andrea.typst.defaultTemplate": {
+					"anhName": "默认模板",
+					"type": "string",
+					"default": "sample",
+					"description": "默认模板包名称"
+				},
+				"andrea.typst.defaultRenderer": {
+					"anhName": "默认 Typst 渲染器",
+					"type": "string",
+					"default": "internal",
+					"markdownDescription": "Typst 内容生成器。`internal` 使用 ANH 内置 Liquid 模板渲染；脚本可通过 `ctx.renderers.registerTypst` 或 `ctx.processors.registerTypst` 注册新的渲染器 ID。"
+				},
+				"andrea.typst.output.format": {
+					"anhName": "导出格式",
+					"type": "string",
+					"enum": [
+						"pdf",
+						"png",
+						"svg"
+					],
+					"default": "pdf",
+					"description": "导出格式"
+				},
+				"andrea.typst.output.ppi": {
+					"anhName": "导出分辨率",
+					"type": "number",
+					"default": 144,
+					"description": "PNG 导出分辨率（PPI）"
+				},
+				"andrea.typst.pages": {
+					"anhName": "导出页码范围",
+					"type": "string",
+					"default": "",
+					"description": "导出页码范围（例如 2,3-6,8-）"
+				},
+				"andrea.typst.font.paths": {
+					"anhName": "字体路径",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "额外字体搜索路径"
+				},
+				"andrea.typst.cleanupTemp": {
+					"anhName": "清理临时文件",
+					"type": "boolean",
+					"default": false,
+					"description": "导出后是否自动清理临时编译目录 build/typst/tmp-*（默认不清理，便于诊断）"
+				},
+				"andrea.typst.preview.storage": {
+					"anhName": "预览存储方式",
+					"type": "string",
+					"enum": [
+						"memory",
+						"file"
+					],
+					"default": "memory",
+					"markdownDescription": "Typst预览文件存储方式：\n- `memory`：存储在虚拟内存盘上（andrea-typst://），实时预览\n- `file`：存储在临时文件目录中，使用绝对路径"
+				},
+				"andrea.typst.preview.tempDir": {
+					"anhName": "预览临时目录",
+					"type": "string",
+					"default": "${workspaceFolder}/build/typst/preview",
+					"markdownDescription": "Typst预览临时文件目录（当preview.storage为'file'时使用）"
+				},
+				"AndreaNovelHelper.scripts.root": {
+					"anhName": "脚本根目录",
+					"type": "string",
+					"default": "novel-helper/scripts",
+					"markdownDescription": "脚本运行侧栏的根目录"
+				},
+				"AndreaNovelHelper.scripts.defaultPlainTextProcessor": {
+					"anhName": "默认纯文本处理器",
+					"type": "string",
+					"default": "internal",
+					"markdownDescription": "复制纯文本和导出 TXT 时使用的处理器。`internal` 使用 ANH 内置 Markdown/TXT 转纯文本逻辑；脚本可通过 `ctx.processors.registerPlainText` 注册新的处理器 ID。"
+				},
+				"AndreaNovelHelper.autoScroll.enabled": {
+					"anhName": "启用自动滚动",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "启用编辑器自动滚动到文档末尾功能。当文档内容变化时，自动滚动到指定的比例位置。"
+				},
+				"AndreaNovelHelper.autoScroll.ratio": {
+					"anhName": "滚动比例",
+					"type": "number",
+					"default": 1,
+					"minimum": 0.1,
+					"maximum": 0.7,
+					"markdownDescription": "自动滚动的目标比例（0.1-0.7）。1.0 表示完全滚动到底部，0.5 表示滚动到中间位置。"
+				},
+				"AndreaNovelHelper.autoScroll.debounceDelay": {
+					"anhName": "防抖延迟",
+					"type": "number",
+					"default": 0,
+					"minimum": 0,
+					"maximum": 2000,
+					"markdownDescription": "自动滚动的防抖延迟时间（毫秒）。避免频繁滚动导致的抖动。 如果0 则立即触发"
+				},
+				"AndreaNovelHelper.whatsNew.autoShow": {
+					"anhName": "自动显示 What's New",
+					"type": "boolean",
+					"default": true,
+					"description": "更新到新版后自动显示 What's New 页面"
+				},
+				"AndreaNovelHelper.txtMigration.enabled": {
+					"anhName": "TXT 角色档案迁移",
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "启用 TXT 角色档案自动检测和一键迁移功能。开启后会在项目打开时自动扫描并提示转换。"
+				},
+				"AndreaNovelHelper.txtMigration.detectionKeywords": {
+					"anhName": "检测关键词",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"角色",
+						"人物",
+						"character",
+						"role",
+						"主角",
+						"配角",
+						"登场",
+						"设定",
+						"信息",
+						"档案",
+						"介绍"
+					],
+					"markdownDescription": "用于识别 TXT 角色档案的文件名关键词。文件名包含任一关键词即进入候选列表。"
+				},
+				"AndreaNovelHelper.txtMigration.highConfidenceDirs": {
+					"anhName": "高置信度目录",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"角色",
+						"人物",
+						"characters",
+						"roles"
+					],
+					"markdownDescription": "这些目录名下的文件会以更低的评分阈值被识别为角色档案。"
+				},
+				"AndreaNovelHelper.txtMigration.scoreThreshold": {
+					"anhName": "评分阈值",
+					"type": "number",
+					"default": 50,
+					"minimum": 0,
+					"maximum": 100,
+					"markdownDescription": "内容评分阈值（0-100）。普通目录下的 TXT 文件需达到此分数才被视为角色档案候选。"
+				},
+				"AndreaNovelHelper.txtMigration.highConfidenceScoreThreshold": {
+					"anhName": "高置信度目录评分阈值",
+					"type": "number",
+					"default": 30,
+					"minimum": 0,
+					"maximum": 100,
+					"markdownDescription": "高置信度目录下的 TXT 文件使用此更低的评分阈值。"
+				}
+			}
+		},
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
+					"when": "andrea.anh.enabled && resourceExtname == .json5",
+					"group": "navigation"
+				},
+				{
+					"command": "andrea.typst.exportFromExplorer",
+					"when": "resourceExtname == .md",
+					"group": "navigation@100"
+				},
+				{
+					"command": "andrea.typst.exportFromExplorer",
+					"when": "resourceExtname == .txt",
+					"group": "navigation@100"
+				},
+				{
+					"command": "andrea.typst.exportFromExplorer",
+					"when": "explorerResourceIsFolder",
+					"group": "navigation@100"
+				},
+				{
+					"command": "AndreaNovelHelper.fileTracker.openShardForFile",
+					"when": "resourceScheme == file && config.AndreaNovelHelper.database.backend == json",
+					"group": "navigation@120"
+				}
+			],
+			"view/title": [
+				{
+					"command": "andrea.configureDocRoles",
+					"when": "view == docRolesView || view == docRolesExplorerView",
+					"group": "navigation@100"
+				},
+				{
+					"command": "andrea.configureAllRoles",
+					"when": "view == roleHierarchyView",
+					"group": "navigation@100"
+				},
+				{
+					"command": "andrea.scripts.openFolder",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@1",
+					"icon": "$(folder-opened)"
+				},
+				{
+					"command": "andrea.scripts.openMcpConfig",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@2",
+					"icon": "$(gear)"
+				},
+				{
+					"command": "andrea.scripts.toggleMcpServers",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@4",
+					"icon": "$(server-process)"
+				},
+				{
+					"command": "andrea.scripts.selectPlainTextProcessor",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@4.5",
+					"icon": "$(settings-gear)"
+				},
+				{
+					"command": "andrea.scripts.selectTypstRenderer",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@4.6",
+					"icon": "$(symbol-method)"
+				},
+				{
+					"command": "andrea.scripts.newScript",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@5",
+					"icon": "$(new-file)"
+				},
+				{
+					"command": "andrea.scripts.refresh",
+					"when": "view == andrea.scriptsView",
+					"group": "navigation@6",
+					"icon": "$(refresh)"
+				},
+				{
+					"command": "andrea.openProjectSettings",
+					"when": "view == andrea.settingsView",
+					"group": "navigation@1",
+					"icon": "$(settings-gear)"
+				}
+			],
+			"view/item/context": [
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createCharacterGallery",
+					"group": "0_create@2"
+				},
+				{
+					"when": "view == andrea.scriptsView && viewItem == andrea.script.file",
+					"command": "andrea.scripts.run",
+					"group": "inline@1",
+					"icon": "$(run)"
+				},
+				{
+					"when": "view == andrea.scriptsView && viewItem == andrea.mcp.server.enabled",
+					"command": "andrea.scripts.toggleSingleServer",
+					"group": "navigation@1",
+					"icon": "$(trash)"
+				},
+				{
+					"when": "view == andrea.scriptsView && viewItem == andrea.mcp.server.disabled",
+					"command": "andrea.scripts.toggleSingleServer",
+					"group": "navigation@1",
+					"icon": "$(add)"
+				},
+				{
+					"when": "view == andrea.scriptsView && viewItem == andrea.script.dir",
+					"command": "andrea.scripts.newScript",
+					"group": "inline@1"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "andrea.openProjectSettings",
+					"group": "0_create@0"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.projectInitWizard.graphical",
+					"group": "0_create@1"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createSensitiveWords",
+					"group": "0_create@3"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createVocabulary",
+					"group": "0_create@4"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createRoleFile",
+					"group": "0_create@5"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createRelationshipFile",
+					"group": "0_create@6"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createTimelineFile",
+					"group": "0_create@7"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createRegexPatterns",
+					"group": "0_create@8"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.showGuide",
+					"group": "0_create@9"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.showGuideDoc",
+					"group": "0_create@10"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == newFile || viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.createSubPackage",
+					"group": "1_package@1"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.deleteNode",
+					"group": "2_deletion"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.openFile",
+					"group": "3_open"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == projectConfigFile || viewItem == missingProjectConfigFile)",
+					"command": "AndreaNovelHelper.openProjectConfigFile",
+					"group": "3_open"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile)",
+					"command": "AndreaNovelHelper.openWith",
+					"group": "3_open"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == projectConfigFile || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.revealInExplorer",
+					"group": "3_open"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == resourceFileError || viewItem == generalResourceFile || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.renamePackage",
+					"group": "1_package@2"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.insertFileAbove",
+					"group": "1_modification@1"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.insertFolderAbove",
+					"group": "1_modification@2"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.insertFileBelow",
+					"group": "1_modification@3"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.insertFolderBelow",
+					"group": "1_modification@4"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.open",
+					"group": "3_open@1"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.openWith",
+					"group": "3_open@2"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.revealInOS",
+					"group": "3_open@3"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.rename",
+					"group": "2_modification@1"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.delete",
+					"group": "2_deletion@9"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.createNewFile",
+					"group": "0_create@1"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.createNewFolder",
+					"group": "0_create@2"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem == wordCountFolder",
+					"command": "AndreaNovelHelper.wordCount.enableManualOrdering",
+					"group": "4_order@1"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem == wordCountFolderManual",
+					"command": "AndreaNovelHelper.wordCount.disableManualOrdering",
+					"group": "4_order@1"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.generateIndexFromName",
+					"group": "4_order@2"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.clearIndex",
+					"group": "4_order@3"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.setIndexManual",
+					"group": "4_order@4"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.bulkGenerateIndices",
+					"group": "4_order@5"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.forceRecountHere",
+					"group": "9_force@1"
+				},
+				{
+					"when": "view == wordCountExplorer",
+					"command": "AndreaNovelHelper.wordCount.forceRecountAll",
+					"group": "9_force@2"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.rescanResourceFilesInFolder",
+					"group": "9_force@3"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.copy",
+					"group": "5_clip@1"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.cut",
+					"group": "5_clip@2"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem == wordCountFile",
+					"command": "WordCount.copyPlainText",
+					"group": "5_clip@4"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem == wordCountFile",
+					"command": "WordCount.exportTxt",
+					"group": "5_clip@5"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem == wordCountFile",
+					"command": "WordCount.exportTxtWithProcessor",
+					"group": "5_clip@5.5"
+				},
+				{
+					"when": "view == wordCountExplorer && (viewItem =~ /^wordCountFolder/ || viewItem == wordCountFile)",
+					"command": "AndreaNovelHelper.wordCount.exportTypst",
+					"group": "5_clip@6"
+				},
+				{
+					"when": "view == wordCountExplorer && viewItem =~ /^wordCountFolder/",
+					"command": "AndreaNovelHelper.wordCount.paste",
+					"group": "5_clip@3"
+				},
+				{
+					"command": "AndreaNovelHelper.toggleRoleManagerOpenForFile",
+					"when": "view == packageManagerView && ( viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError)",
+					"group": "navigation"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.package.copy",
+					"group": "6_clip@1"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == resourceFile || viewItem == generalResourceFile || viewItem == resourceFileError || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.package.cut",
+					"group": "6_clip@2"
+				},
+				{
+					"when": "view == packageManagerView && (viewItem == package || viewItem == externalRoleFolder)",
+					"command": "AndreaNovelHelper.package.paste",
+					"group": "6_clip@3"
+				},
+				{
+					"command": "andrea.webdav.openFile",
+					"when": "view == andrea.webdavFiles && viewItem == webdavFile",
+					"group": "navigation@1"
+				},
+				{
+					"command": "andrea.webdav.renameFile",
+					"when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
+					"group": "2_workspace@1"
+				},
+				{
+					"command": "andrea.webdav.copyFile",
+					"when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
+					"group": "2_workspace@2"
+				},
+				{
+					"command": "andrea.webdav.deleteFile",
+					"when": "view == andrea.webdavFiles && (viewItem == webdavFile || viewItem == webdavFolder)",
+					"group": "2_workspace@3"
+				},
+				{
+					"command": "andrea.webdav.createFolder",
+					"when": "view == andrea.webdavFiles && viewItem == webdavFolder",
+					"group": "3_new@1"
+				},
+				{
+					"command": "andrea.webdav.uploadFile",
+					"when": "view == andrea.webdavFiles && viewItem == webdavFolder",
+					"group": "3_new@2"
+				},
+				{
+					"command": "andrea.commentsExplorer.openComment",
+					"when": "view == andrea.commentsExplorer && (viewItem == commentThread || viewItem == commentMessage)",
+					"group": "navigation@1"
+				},
+				{
+					"command": "andrea.commentsExplorer.toggleStatus",
+					"when": "view == andrea.commentsExplorer && viewItem == commentThread",
+					"group": "1_modification@1"
+				},
+				{
+					"command": "andrea.commentsExplorer.rebindFileToDocument",
+					"when": "view == andrea.commentsExplorer && viewItem == commentFile",
+					"group": "1_modification@1"
+				},
+				{
+					"command": "andrea.commentsExplorer.refresh",
+					"when": "view == andrea.commentsExplorer",
+					"group": "navigation@2"
+				},
+				{
+					"command": "andrea.commentsExplorer.search",
+					"when": "view == andrea.commentsExplorer",
+					"group": "navigation@3"
+				},
+				{
+					"command": "andrea.commentsExplorer.filterByStatus",
+					"when": "view == andrea.commentsExplorer",
+					"group": "2_filter@1"
+				},
+				{
+					"command": "andrea.commentsExplorer.clearFilter",
+					"when": "view == andrea.commentsExplorer",
+					"group": "2_filter@2"
+				},
+				{
+					"command": "andrea.commentsExplorer.exportComments",
+					"when": "view == andrea.commentsExplorer",
+					"group": "3_export@1"
+				},
+				{
+					"command": "andrea.commentsExplorer.exportToMarkdown",
+					"when": "view == andrea.commentsExplorer",
+					"group": "3_export@2"
+				},
+				{
+					"command": "andrea.commentsExplorer.exportToJson",
+					"when": "view == andrea.commentsExplorer",
+					"group": "3_export@3"
+				},
+				{
+					"when": "view == andrea.scriptsView && viewItem == andrea.script.file",
+					"command": "andrea.scripts.run",
+					"group": "navigation@1",
+					"icon": "$(run-all)"
+				},
+				{
+					"when": "view == andrea.scriptsView",
+					"command": "andrea.scripts.newScript",
+					"group": "0_create@1"
+				},
+				{
+					"when": "view == andrea.scriptsView",
+					"command": "andrea.scripts.renameScript",
+					"group": "2_modification@1"
+				},
+				{
+					"when": "view == andrea.scriptsView",
+					"command": "andrea.scripts.deleteScript",
+					"group": "2_deletion@9"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "myPreview.open",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation"
+				},
+				{
+					"command": "andrea.comments.open",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation@101"
+				},
+				{
+					"command": "AndreaNovelHelper.openDoubleOutline",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation"
+				},
+				{
+					"command": "AndreaNovelHelper.openOutlinePicker",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation@102"
+				},
+				{
+					"command": "AndreaNovelHelper.redirectOutlineHere",
+					"when": "resourceScheme == andrea-outline",
+					"group": "navigation@103"
+				},
+				{
+					"command": "AndreaNovelHelper.openTypstPreview",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation@104",
+					"icon": "$(preview)"
+				},
+				{
+					"command": "AndreaNovelHelper.changeTypstTemplate",
+					"when": "resourceScheme == andrea-typst",
+					"group": "navigation@105",
+					"icon": "$(settings)"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "andrea.formatDocument",
+					"when": "andrea.anh.enabled && (editorLangId == markdown || editorLangId == plaintext || editorLangId == json5)",
+					"group": "navigation@9"
+				},
+				{
+					"command": "andrea.formatDocument.addBlanks",
+					"when": "andrea.anh.enabled && (editorLangId == markdown || editorLangId == plaintext)",
+					"group": "navigation@9"
+				},
+				{
+					"command": "andrea.typst.exportCurrent",
+					"when": "(editorLangId == markdown || editorLangId == plaintext) && resourceScheme == file",
+					"group": "navigation@100"
+				},
+				{
+					"when": "andrea.anh.enabled && editorHasSelection && (editorLangId == markdown || editorLangId == plaintext)",
+					"command": "andrea.comments.add",
+					"group": "1_modification@97"
+				},
+				{
+					"when": "andrea.anh.enabled && editorTextFocus && (editorLangId == markdown || editorLangId == plaintext)",
+					"command": "andrea.comments.open",
+					"group": "navigation@97"
+				},
+				{
+					"when": "andrea.anh.enabled && editorHasSelection",
+					"command": "AndreaNovelHelper.addRoleFromSelection",
+					"group": "navigation"
+				},
+				{
+					"when": "andrea.anh.enabled && editorHasSelection",
+					"command": "AndreaNovelHelper.addSensitiveWord",
+					"group": "navigation"
+				},
+				{
+					"when": "andrea.anh.enabled && editorHasSelection",
+					"command": "AndreaNovelHelper.addVocabulary",
+					"group": "navigation"
+				},
+				{
+					"when": "andrea.anh.enabled && editorTextFocus && resourceExtname == .md && editorHasSelection",
+					"command": "AndreaNovelHelper.showMarkdownFormatMenu",
+					"group": "1_modification@1"
+				},
+				{
+					"when": "andrea.anh.enabled && editorTextFocus && (editorLangId == markdown || editorLangId == plaintext)",
+					"command": "myPreview.copyPlainText",
+					"group": "navigation@8"
+				},
+				{
+					"when": "andrea.anh.enabled && editorHasSelection && (editorLangId == markdown || editorLangId == plaintext)",
+					"command": "andrea.typo.translateSelection",
+					"group": "navigation@98"
+				},
+				{
+					"when": "andrea.anh.enabled",
+					"command": "andrea-novel-helper.generateRandomCharacter",
+					"group": "navigation@99"
+				},
+				{
+					"when": "andrea.anh.enabled",
+					"command": "andrea-novel-helper.generateStepByStepCharacter",
+					"group": "navigation@100"
+				},
+				{
+					"command": "AndreaNovelHelper.fileTracker.openShardForFile",
+					"when": "resourceScheme == file && config.AndreaNovelHelper.database.backend == json",
+					"group": "navigation@120"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "AndreaNovelHelper.refreshRoles",
+					"group": "navigation"
+				},
+				{
+					"command": "AndreaNovelHelper.refreshSensitiveWords",
+					"group": "navigation"
+				},
+				{
+					"command": "AndreaNovelHelper.refreshVocabulary",
+					"group": "navigation"
+				}
+			]
+		},
+		"views": {
+			"explorer": [
+				{
+					"id": "wordCountExplorer",
+					"name": "写作资源管理器（小说助手）",
+					"icon": "book",
+					"when": "andrea.anh.enabled"
+				},
+				{
+					"id": "docRolesExplorerView",
+					"name": "当前文章角色",
+					"icon": "account",
+					"when": "andrea.anh.enabled"
+				}
+			],
+			"AndreaNovelHelperSidebar": [
+				{
+					"id": "packageManagerView",
+					"name": "包管理器",
+					"icon": "package"
+				},
+				{
+					"id": "docRolesView",
+					"name": "当前文章角色",
+					"icon": "person"
+				},
+				{
+					"id": "roleHierarchyView",
+					"name": "角色",
+					"icon": "organization"
+				}
+			],
+			"AndreaCommentsSidebar": [
+				{
+					"id": "andrea.commentsExplorer",
+					"name": "%view.comments.explorer.name%",
+					"icon": "comment-discussion"
+				},
+				{
+					"id": "andrea.commentsPanelView",
+					"type": "webview",
+					"name": "%view.comments.panel.name%",
+					"icon": "comment"
+				},
+				{
+					"id": "andrea.commentsManagerView",
+					"type": "webview",
+					"name": "%view.comments.manager.name%",
+					"icon": "list-flat"
+				}
+			],
+			"AndreaWebDAVSidebar": [
+				{
+					"id": "andrea.webdavPanel",
+					"type": "webview",
+					"name": "%view.webdav.panel.name%",
+					"icon": "cloud"
+				},
+				{
+					"id": "andrea.webdavFiles",
+					"name": "%view.webdav.files.name%",
+					"icon": "cloud-download"
+				},
+				{
+					"id": "andrea.autoGitPanel",
+					"name": "AutoGit 管理",
+					"icon": "git-branch"
+				}
+			],
+			"AndreaScriptsSidebar": [
+				{
+					"id": "andrea.scriptsView",
+					"name": "%view.scripts.name%",
+					"icon": "run"
+				}
+			],
+			"AndreaSettingsSidebar": [
+				{
+					"id": "andrea.settingsView",
+					"type": "webview",
+					"name": "设置",
+					"icon": "gear"
+				}
+			]
+		},
+		"keybindings": [
+			{
+				"key": "enter",
+				"command": "andrea.smartEnter",
+				"when": "andrea.anh.enabled && editorTextFocus && andrea.typeset.smartEnterOn && !editorReadonly && (!suggestWidgetVisible || config.editor.acceptSuggestionOnEnter == 'off') && !inlineSuggestionVisible && !editorHasMultipleSelections && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode'"
+			},
+			{
+				"key": "ctrl+alt+i",
+				"command": "andrea.quickSettings",
+				"when": "editorTextFocus"
+			}
+		]
+	},
+	"workspaces": [
+		"packages/webview",
+		"packages/enigo-keyboard"
+	],
+	"scripts": {
+		"bundle:ext": "esbuild src/extension.ts --bundle --platform=node --format=cjs --target=node20 --external:vscode --main-fields=module,main --outfile=out/extension.js --sourcemap",
+		"build:webview": "npm --workspace=packages/webview run build",
+		"dev:webview": "npm --workspace=packages/webview run dev",
+		"vscode:prepublish": "npm run build:webview && npm run compile",
+		"compile": "node scripts/translate-nls2l10n.js && tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"pretest": "npm run compile && npm run lint",
+		"lint": "eslint src",
+		"test": "vscode-test",
+		"test:role-load-refresh": "npm run compile && mocha --ui tdd --require ./scripts/register-node-unit-test-env.js \"out/test/roleLoadRefresh.unit.test.js\"",
+		"publish:artifacts": "node scripts/publish-artifacts.js",
+		"mcp:test": "ts-node scripts/mcp-test.ts",
+		"mcp:run": "ts-node scripts/mcp-run.ts",
+		"mcp:bing-dom": "ts-node scripts/mcp-run.ts scripts/mcp-scripts/open-bing-get-dom.js",
+		"mcp:bing-input": "ts-node scripts/mcp-run.ts scripts/mcp-scripts/open-bing-input-zh.js"
+	},
+	"devDependencies": {
+		"@types/mocha": "^10.0.10",
+		"@types/node": "^20.19.11",
+		"@types/vscode": "^1.95.0",
+		"@typescript-eslint/eslint-plugin": "^8.31.1",
+		"@typescript-eslint/parser": "^8.31.1",
+		"@vscode/test-cli": "^0.0.11",
+		"@vscode/test-electron": "^2.5.2",
+		"esbuild": "^0.25.9",
+		"eslint": "^9.25.1",
+		"mocha": "^11.7.5",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.8.3"
+	},
+	"dependencies": {
+		"@anh/enigo-keyboard": "^0.1.0",
+		"@cfworker/json-schema": "^4.1.1",
+		"@faker-js/faker": "^10.1.0",
+		"@modelcontextprotocol/sdk": "^1.22.0",
+		"@node-rs/jieba": "^2.0.1",
+		"@types/uuid": "^10.0.0",
+		"@vscode/sqlite3": "^5.1.8-vscode",
+		"ahocorasick": "^1.0.2",
+		"chardet": "^2.1.0",
+		"chart.js": "^4.5.0",
+		"chartjs-adapter-date-fns": "^3.0.0",
+		"fast-glob": "^3.3.3",
+		"font-list": "^1.5.1",
+		"iconv-lite": "^0.6.3",
+		"ignore": "^7.0.5",
+		"jschardet": "^3.1.4",
+		"json5": "^2.2.3",
+		"jsonc-parser": "^3.3.1",
+		"kuroshiro": "^1.2.0",
+		"kuroshiro-analyzer-kuromoji": "^1.1.0",
+		"liquidjs": "^10.24.0",
+		"memfs": "^4.17.2",
+		"pinyin-pro": "^3.28.1",
+		"transliteration": "^2.6.1",
+		"uuid": "^11.1.0",
+		"wanakana": "^5.3.1",
+		"webdav": "^5.7.0",
+		"zod": "^4.3.6"
+	}
 }

--- a/src/Provider/view/packageManagerView.ts
+++ b/src/Provider/view/packageManagerView.ts
@@ -89,6 +89,20 @@ function resolveFileConflict(dir: string, baseName: string, ext: string): { path
     }
 }
 
+// TXT 角色档案检测缓存（避免在 TreeView getChildren() 中同步扫描阻塞 UI）
+let cachedTxtCandidates: import('../../utils/txtRoleDetector').TxtRoleFileCandidate[] = [];
+let txtCandidateRefreshTimer: NodeJS.Timeout | undefined;
+
+function scheduleTxtCandidateRefresh() {
+    if (txtCandidateRefreshTimer) return;
+    txtCandidateRefreshTimer = setTimeout(() => {
+        txtCandidateRefreshTimer = undefined;
+        try {
+            cachedTxtCandidates = detectTxtRoleFilesAll();
+        } catch { /* 静默失败 */ }
+    }, 100);
+}
+
 class CommonFeaturesRootNode extends vscode.TreeItem {
     public readonly resourceUri: vscode.Uri;
     public readonly id: string;
@@ -690,11 +704,16 @@ export class PackageManagerProvider implements vscode.TreeDataProvider<PackageMa
                 new DocCenterNode(this.workspaceRoot),
                 new GraphicalQuickSettingsNode(this.workspaceRoot),
             ];
-            // 检测到 TXT 角色档案且无 JSON5 库时，显示迁移入口
-            const candidates = detectTxtRoleFilesAll();
-            const json5Path = path.join(this.workspaceRoot, 'novel-helper', 'character-gallery.json5');
-            if (candidates.length > 0 && !fs.existsSync(json5Path)) {
-                children.unshift(new TxtMigrationNode(this.workspaceRoot));
+            // 检测到 TXT 角色档案且无 JSON5 库时，显示迁移入口（需功能启用，使用缓存避免阻塞 UI）
+            const migrationEnabled = vscode.workspace.getConfiguration('AndreaNovelHelper')
+                .get<boolean>('txtMigration.enabled', true);
+            if (migrationEnabled) {
+                // 异步刷新缓存（不阻塞 TreeView 渲染），首次渲染使用最后一次缓存结果
+                scheduleTxtCandidateRefresh();
+                const json5Path = path.join(this.workspaceRoot, 'novel-helper', 'character-gallery.json5');
+                if (cachedTxtCandidates.length > 0 && !fs.existsSync(json5Path)) {
+                    children.unshift(new TxtMigrationNode(this.workspaceRoot));
+                }
             }
             return children;
         }

--- a/src/Provider/view/packageManagerView.ts
+++ b/src/Provider/view/packageManagerView.ts
@@ -8,6 +8,7 @@ import { Role } from '../../extension';
 import { generateCharacterGalleryJson5, generateSensitiveWordsJson5, generateVocabularyJson5, generateRegexPatternsTemplate, generateMarkdownRegexPatternsTemplate, generateMarkdownRoleTemplate, generateMarkdownSensitiveTemplate, generateMarkdownVocabularyTemplate } from '../../templates/templateGenerators';
 import { statSync } from 'fs';
 import { loadRoles, scanExternalRoleFoldersWithReport, ExternalRoleFolderScanReport, isExternalResourceMarkerFile, isPathUnderAnyRoot, isRoleFile } from '../../utils/utils';
+import { detectTxtRoleFilesAll } from '../../utils/txtRoleDetector';
 import { generateUUIDv7 } from '../../utils/uuidUtils';
 import { updateDecorations } from '../../events/updateDecorations';
 import { registerFileChangeCallback, unregisterFileChangeCallback, FileChangeEvent } from '../../utils/tracker/globalFileTracking';
@@ -387,6 +388,25 @@ class BookRootNode extends vscode.TreeItem {
         this.description = '书籍根目录';
     }
 }
+
+// TXT 角色档案迁移节点（仅在检测到候选且无 JSON5 库时显示）
+class TxtMigrationNode extends vscode.TreeItem {
+    public readonly resourceUri: vscode.Uri;
+
+    constructor(public readonly workspaceRoot: string) {
+        super('+ 转换 TXT 角色档案', vscode.TreeItemCollapsibleState.None);
+        this.resourceUri = vscode.Uri.file(workspaceRoot);
+        this.contextValue = 'txtMigration';
+        this.iconPath = new vscode.ThemeIcon('arrow-swap');
+        this.description = '将 TXT 角色档案转换为 JSON5 格式';
+        this.command = {
+            command: 'andrea.detectTxtRoleFiles',
+            title: '检测并转换 TXT 角色档案',
+            arguments: []
+        };
+    }
+}
+
 /**
  * Represents a package (folder) or resource file under novel-helper
  */
@@ -655,7 +675,7 @@ export class PackageManagerProvider implements vscode.TreeDataProvider<PackageMa
         }
 
         if (node instanceof CommonFeaturesRootNode) {
-            return [
+            const children: PackageManagerNode[] = [
                 new HelloPageNode(this.workspaceRoot),
                 new ProjectInitWizardNode(this.workspaceRoot),
                 new ProjectSettingsNode(this.workspaceRoot),
@@ -668,8 +688,15 @@ export class PackageManagerProvider implements vscode.TreeDataProvider<PackageMa
                 new GenerateLookupKeysNode(this.workspaceRoot),
                 new GuideNode(this.workspaceRoot),
                 new DocCenterNode(this.workspaceRoot),
-                new GraphicalQuickSettingsNode(this.workspaceRoot)
+                new GraphicalQuickSettingsNode(this.workspaceRoot),
             ];
+            // 检测到 TXT 角色档案且无 JSON5 库时，显示迁移入口
+            const candidates = detectTxtRoleFilesAll();
+            const json5Path = path.join(this.workspaceRoot, 'novel-helper', 'character-gallery.json5');
+            if (candidates.length > 0 && !fs.existsSync(json5Path)) {
+                children.unshift(new TxtMigrationNode(this.workspaceRoot));
+            }
+            return children;
         }
 
         if (node instanceof ProjectSettingsFilesRootNode) {

--- a/src/activate.ts
+++ b/src/activate.ts
@@ -42,6 +42,7 @@ import { projectInitWizardRunning, registerProjectInitWizard } from './wizard/pr
 import { registerGraphicalProjectInitWizard } from './wizard/projectInitWizardPage';
 import { registerGuidePage } from './guide/guidePage';
 import { registerWhatsNewPage } from './whatsnew/whatsnew-panel';
+import { registerTxtMigrationCommands } from './commands/txtMigrationCommands';
 import { checkAndShowWhatsNew } from './whatsnew/version-check';
 import { clearAllRoleMatchCache } from './context/roleAsyncShared';
 import { initializeRoleUsageStore, disposeRoleUsageStore, renameRoleUsageDirectory, deleteRoleUsageDirectory, clearRoleUsageIndex, updateRoleUsageFromDocument } from './context/roleUsageStore';
@@ -217,6 +218,7 @@ export async function activate(context: vscode.ExtensionContext) {
         registerDocViewerPage(context);
         registerHelloPage(context);
         registerWhatsNewPage(context);
+        registerTxtMigrationCommands(context);
         registerQuickSettingsPage(context);
         log('项目初始化/文档向导命令已注册');
     } catch (e) { log('注册 项目初始化/文档向导命令 失败', e); }

--- a/src/commands/txtMigrationCommands.ts
+++ b/src/commands/txtMigrationCommands.ts
@@ -1,0 +1,215 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { detectTxtRoleFilesAll, type TxtRoleFileCandidate } from '../utils/txtRoleDetector';
+import { parseTxtRoleFile, toJson5, toMarkdown } from '../utils/txtRoleParser';
+
+let statusBarItem: vscode.StatusBarItem | undefined;
+
+/** 注册检测与迁移命令 */
+export function registerTxtMigrationCommands(context: vscode.ExtensionContext) {
+    // 命令：检测 TXT 角色文件
+    context.subscriptions.push(
+        vscode.commands.registerCommand('andrea.detectTxtRoleFiles', async () => {
+            await detectAndShowResults();
+        })
+    );
+
+    // 命令：迁移选中的 TXT 文件
+    context.subscriptions.push(
+        vscode.commands.registerCommand('andrea.migrateTxtRoleFile', async (candidate: TxtRoleFileCandidate) => {
+            await migrateSingleFile(candidate);
+        })
+    );
+
+    // 状态栏：显示检测提示
+    updateStatusBar();
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeWorkspaceFolders(() => updateStatusBar())
+    );
+}
+
+async function updateStatusBar() {
+    const candidates = detectTxtRoleFilesAll();
+    if (candidates.length > 0) {
+        if (!statusBarItem) {
+            statusBarItem = vscode.window.createStatusBarItem('andrea.txtRoleDetector', vscode.StatusBarAlignment.Right, 100);
+            statusBarItem.command = 'andrea.detectTxtRoleFiles';
+        }
+        statusBarItem.text = `$(search) ${candidates.length} 个 TXT 角色档案`;
+        statusBarItem.tooltip = '检测到可迁移为 JSON5 的角色档案文件，点击查看';
+        statusBarItem.show();
+
+        // 自动提示：如果没有 character-gallery.json5，弹窗提醒
+        const folders = vscode.workspace.workspaceFolders;
+        if (folders?.length) {
+            const json5Path = path.join(folders[0].uri.fsPath, 'novel-helper', 'character-gallery.json5');
+            if (!fs.existsSync(json5Path)) {
+                const action = await vscode.window.showInformationMessage(
+                    `检测到 ${candidates.length} 个 TXT 角色档案，可转换为标准 JSON5 格式`,
+                    '开始转换',
+                    '稍后'
+                );
+                if (action === '开始转换') {
+                    await vscode.commands.executeCommand('andrea.detectTxtRoleFiles');
+                }
+            }
+        }
+    } else {
+        statusBarItem?.hide();
+    }
+}
+
+async function detectAndShowResults() {
+    const candidates = detectTxtRoleFilesAll();
+
+    if (candidates.length === 0) {
+        vscode.window.showInformationMessage('未检测到可迁移的 TXT 角色档案文件。');
+        return;
+    }
+
+    // 构建 QuickPick 列表
+    const items: (vscode.QuickPickItem & { candidate: TxtRoleFileCandidate })[] = candidates.map(c => ({
+        label: `$(file-text) ${c.fileName}`,
+        description: `评分 ${c.score}/100 · ${c.lineCount} 行`,
+        detail: c.summary,
+        candidate: c,
+    }));
+
+    items.unshift({
+        label: '$(arrow-swap) 迁移全部（一键转换）',
+        description: `共 ${candidates.length} 个文件`,
+        detail: '将自动检测到的所有 TXT 角色档案转换为 JSON5 格式（原文件保留 .bak 备份）',
+        candidate: null as any,
+    } as any);
+
+    const selected = await vscode.window.showQuickPick(items, {
+        matchOnDescription: true,
+        matchOnDetail: true,
+        placeHolder: `发现 ${candidates.length} 个候选 TXT 角色档案，选择要迁移的文件`,
+        title: 'TXT 角色档案迁移',
+    });
+
+    if (!selected) return;
+
+    // "迁移全部"
+    if ((selected as any).label.startsWith('$(arrow-swap)')) {
+        for (const c of candidates) {
+            await migrateSingleFile(c);
+        }
+        return;
+    }
+
+    // 单个文件：先预览再确认
+    if ((selected as any).candidate) {
+        const c = (selected as any).candidate as TxtRoleFileCandidate;
+        const confirmed = await previewMigration(c);
+        if (confirmed) {
+            await migrateSingleFile(c);
+        }
+    }
+}
+
+async function previewMigration(candidate: TxtRoleFileCandidate): Promise<boolean> {
+    let content: string;
+    try {
+        content = fs.readFileSync(candidate.filePath, 'utf8');
+    } catch {
+        vscode.window.showErrorMessage(`无法读取文件: ${candidate.fileName}`);
+        return false;
+    }
+
+    const result = parseTxtRoleFile(content, candidate.filePath);
+
+    if (result.totalRoles === 0) {
+        vscode.window.showWarningMessage(`未能从 ${candidate.fileName} 解析出角色。该文件可能不是角色档案格式。`);
+        return false;
+    }
+
+    // Pop up a confirmation dialog with details
+    const sectionSummary = result.sections
+        .map(s => `  ${s.sectionTitle}: ${s.roles.length} 个角色`)
+        .join('\n');
+
+    const choice = await vscode.window.showInformationMessage(
+        `"${candidate.fileName}"\n共解析出 ${result.totalRoles} 个角色:\n${sectionSummary}\n\n转换格式？`,
+        { modal: true },
+        '转为 JSON5 (推荐)',
+        '转为 Markdown',
+        '取消'
+    );
+
+    if (!choice || choice === '取消') return false;
+
+    // Store the choice for migration
+    (candidate as any)._format = choice.includes('JSON5') ? 'json5' : 'md';
+    return true;
+}
+
+async function migrateSingleFile(candidate: TxtRoleFileCandidate) {
+    const format: 'json5' | 'md' = (candidate as any)._format || 'json5';
+
+    let content: string;
+    try {
+        content = fs.readFileSync(candidate.filePath, 'utf8');
+    } catch {
+        vscode.window.showErrorMessage(`无法读取文件: ${candidate.fileName}`);
+        return;
+    }
+
+    const result = parseTxtRoleFile(content, candidate.filePath);
+    if (result.totalRoles === 0) {
+        vscode.window.showWarningMessage(`未能从 ${candidate.fileName} 解析出角色。`);
+        return;
+    }
+
+    // 备份原文件
+    const bakPath = candidate.filePath + '.bak';
+    try {
+        fs.copyFileSync(candidate.filePath, bakPath);
+    } catch {
+        vscode.window.showErrorMessage(`备份失败: ${bakPath}`);
+        return;
+    }
+
+    // 生成目标内容
+    const outputContent = format === 'json5' ? toJson5(result) : toMarkdown(result);
+    const outputExt = format === 'json5' ? '.json5' : '.md';
+
+    // 输出到 novel-helper 目录
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders?.length) return;
+    const novelHelperDir = path.join(folders[0].uri.fsPath, 'novel-helper');
+    fs.mkdirSync(novelHelperDir, { recursive: true });
+
+    // 使用标准默认文件名
+    const defaultName = format === 'json5' ? 'character-gallery.json5' : 'character-gallery.md';
+    let outputPath = path.join(novelHelperDir, defaultName);
+
+    // 如果已存在，问用户是覆盖还是取消
+    if (fs.existsSync(outputPath)) {
+        const action = await vscode.window.showWarningMessage(
+            `${defaultName} 已存在。覆盖会丢失手动修改的内容。`,
+            { modal: true },
+            '覆盖',
+            '取消'
+        );
+        if (action !== '覆盖') return;
+    }
+
+    fs.writeFileSync(outputPath, outputContent, 'utf8');
+
+    const relativeOutput = path.relative(folders[0].uri.fsPath, outputPath);
+
+    vscode.window.showInformationMessage(
+        `已迁移: ${candidate.fileName} → ${relativeOutput} (${result.totalRoles} 个角色)`,
+        '打开文件',
+        '刷新角色'
+    ).then(choice => {
+        if (choice === '打开文件') {
+            vscode.commands.executeCommand('vscode.open', vscode.Uri.file(outputPath));
+        } else if (choice === '刷新角色') {
+            vscode.commands.executeCommand('AndreaNovelHelper.refreshRole');
+        }
+    });
+}

--- a/src/commands/txtMigrationCommands.ts
+++ b/src/commands/txtMigrationCommands.ts
@@ -6,6 +6,18 @@ import { parseTxtRoleFile, toJson5, toMarkdown } from '../utils/txtRoleParser';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 
+/** 根据文件路径找到对应的工作区文件夹，找不到时回退到 workspaceFolders[0] */
+function getWorkspaceRootForFile(filePath: string): string | undefined {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders?.length) return undefined;
+    const normalized = path.resolve(filePath).replace(/\\/g, '/').toLowerCase();
+    for (const f of folders) {
+        const root = path.resolve(f.uri.fsPath).replace(/\\/g, '/').toLowerCase();
+        if (normalized.startsWith(root + '/')) return f.uri.fsPath;
+    }
+    return folders[0].uri.fsPath;
+}
+
 /** 注册检测与迁移命令 */
 export function registerTxtMigrationCommands(context: vscode.ExtensionContext) {
     // 命令：检测 TXT 角色文件
@@ -23,13 +35,21 @@ export function registerTxtMigrationCommands(context: vscode.ExtensionContext) {
     );
 
     // 状态栏：显示检测提示
+    context.subscriptions.push({ dispose: () => statusBarItem?.dispose() });
     updateStatusBar();
     context.subscriptions.push(
         vscode.workspace.onDidChangeWorkspaceFolders(() => updateStatusBar())
     );
 }
 
+function isMigrationEnabled(): boolean {
+    return vscode.workspace.getConfiguration('AndreaNovelHelper')
+        .get<boolean>('txtMigration.enabled', true);
+}
+
 async function updateStatusBar() {
+    if (!isMigrationEnabled()) { statusBarItem?.hide(); return; }
+
     const candidates = detectTxtRoleFilesAll();
     if (candidates.length > 0) {
         if (!statusBarItem) {
@@ -61,6 +81,10 @@ async function updateStatusBar() {
 }
 
 async function detectAndShowResults() {
+    if (!isMigrationEnabled()) {
+        vscode.window.showInformationMessage('TXT 角色档案迁移功能未启用。可在设置中开启 AndreaNovelHelper.txtMigration.enabled。');
+        return;
+    }
     const candidates = detectTxtRoleFilesAll();
 
     if (candidates.length === 0) {
@@ -174,22 +198,22 @@ async function migrateSingleFile(candidate: TxtRoleFileCandidate) {
 
     // 生成目标内容
     const outputContent = format === 'json5' ? toJson5(result) : toMarkdown(result);
-    const outputExt = format === 'json5' ? '.json5' : '.md';
 
-    // 输出到 novel-helper 目录
-    const folders = vscode.workspace.workspaceFolders;
-    if (!folders?.length) return;
-    const novelHelperDir = path.join(folders[0].uri.fsPath, 'novel-helper');
+    // 输出到正确的 novel-helper 目录（按文件所在工作区，不固定取 [0]）
+    const wsRoot = getWorkspaceRootForFile(candidate.filePath);
+    if (!wsRoot) return;
+    const novelHelperDir = path.join(wsRoot, 'novel-helper');
     fs.mkdirSync(novelHelperDir, { recursive: true });
 
-    // 使用标准默认文件名
-    const defaultName = format === 'json5' ? 'character-gallery.json5' : 'character-gallery.md';
-    let outputPath = path.join(novelHelperDir, defaultName);
+    // 使用原名 + 标准后缀
+    const baseName = path.basename(candidate.filePath, '.txt');
+    const outputName = `${baseName}.${format === 'json5' ? 'json5' : 'md'}`;
+    let outputPath = path.join(novelHelperDir, outputName);
 
     // 如果已存在，问用户是覆盖还是取消
     if (fs.existsSync(outputPath)) {
         const action = await vscode.window.showWarningMessage(
-            `${defaultName} 已存在。覆盖会丢失手动修改的内容。`,
+            `${outputName} 已存在。覆盖会丢失手动修改的内容。`,
             { modal: true },
             '覆盖',
             '取消'
@@ -199,7 +223,7 @@ async function migrateSingleFile(candidate: TxtRoleFileCandidate) {
 
     fs.writeFileSync(outputPath, outputContent, 'utf8');
 
-    const relativeOutput = path.relative(folders[0].uri.fsPath, outputPath);
+    const relativeOutput = path.relative(wsRoot, outputPath);
 
     vscode.window.showInformationMessage(
         `已迁移: ${candidate.fileName} → ${relativeOutput} (${result.totalRoles} 个角色)`,

--- a/src/guide/guidePage.ts
+++ b/src/guide/guidePage.ts
@@ -6,8 +6,127 @@ import { setWebviewPanelIcon } from '../Provider/utils/webviewPanelIcon';
 let currentPanel: vscode.WebviewPanel | undefined;
 let extensionPath: string = '';
 
+// ── 打开配置按钮逻辑 ──────────────────────────────
+
+interface ConfigTypeInfo {
+    defaultNames: string[];      // 默认文件名（不含扩展名）
+    nameKeywords: string[];      // 文件名关键词
+    extensions: string[];        // 有效扩展名
+    templateGenerator: (format: 'json5' | 'md') => string;  // 创建模板用
+    displayName: string;         // 显示名称
+}
+
+const CONFIG_TYPES: Record<string, ConfigTypeInfo> = {
+    role: {
+        defaultNames: ['character-gallery'],
+        nameKeywords: ['character-gallery', 'character', 'role', 'roles'],
+        extensions: ['.json5', '.ojson5', '.md', '.csv', '.txt'],
+        templateGenerator: () => `[\n  {\n    name: "示例角色",\n    type: "配角",\n    description: "这是一个示例角色"\n  }\n]\n`,
+        displayName: '角色管理',
+    },
+    sensitive: {
+        defaultNames: ['sensitive-words'],
+        nameKeywords: ['sensitive-words', 'sensitive', '敏感词'],
+        extensions: ['.json5', '.md', '.txt'],
+        templateGenerator: () => `[\n  {\n    name: "示例敏感词",\n    type: "敏感词",\n    color: "#FF4D4F",\n    description: "需要避免使用的词汇"\n  }\n]\n`,
+        displayName: '敏感词检测',
+    },
+    vocab: {
+        defaultNames: ['vocabulary'],
+        nameKeywords: ['vocabulary', 'vocab', '词汇', '术语'],
+        extensions: ['.json5', '.md', '.txt'],
+        templateGenerator: () => `[\n  {\n    name: "示例词汇",\n    type: "词汇",\n    description: "世界观术语"\n  }\n]\n`,
+        displayName: '词汇表',
+    },
+    regex: {
+        defaultNames: ['regex-patterns'],
+        nameKeywords: ['regex-patterns', 'regex', '正则'],
+        extensions: ['.json5', '.md'],
+        templateGenerator: () => `[\n  {\n    name: "示例规则",\n    type: "正则表达式",\n    regex: "「[^」]*」",\n    regexFlags: "g",\n    color: "#98FB98"\n  }\n]\n`,
+        displayName: '正则着色',
+    },
+};
+
+function findConfigFiles(novelHelperDir: string, info: ConfigTypeInfo): string[] {
+    if (!fs.existsSync(novelHelperDir)) return [];
+    const entries = fs.readdirSync(novelHelperDir, { withFileTypes: true });
+    return entries
+        .filter(e => {
+            if (!e.isFile()) return false;
+            const lower = e.name.toLowerCase();
+            const ext = path.extname(lower);
+            if (!info.extensions.includes(ext)) return false;
+            const base = path.basename(lower, ext);
+            return info.nameKeywords.some(kw => base.toLowerCase().includes(kw.toLowerCase()));
+        })
+        .map(e => path.join(novelHelperDir, e.name));
+}
+
+async function openFileForType(filePath: string, _typeKey: string) {
+    await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(filePath), 'default');
+}
+
+async function openOrCreateConfig(typeKey: string) {
+    const info = CONFIG_TYPES[typeKey];
+    if (!info) return;
+
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders?.length) {
+        vscode.window.showErrorMessage('请先打开一个项目文件夹。');
+        return;
+    }
+
+    const novelHelperDir = path.join(folders[0].uri.fsPath, 'novel-helper');
+    const files = findConfigFiles(novelHelperDir, info);
+
+    if (files.length === 0) {
+        // 没有配置文件 → 引导创建
+        const format = await vscode.window.showQuickPick(['json5', 'md'], {
+            placeHolder: `${info.displayName}: 未找到配置文件。选择格式创建`,
+            title: '创建配置文件'
+        });
+        if (!format) return;
+        const ext = format === 'json5' ? '.json5' : '.md';
+        const fileName = `${info.defaultNames[0]}${ext}`;
+        fs.mkdirSync(novelHelperDir, { recursive: true });
+        const filePath = path.join(novelHelperDir, fileName);
+        if (!fs.existsSync(filePath)) {
+            fs.writeFileSync(filePath, info.templateGenerator(format as 'json5' | 'md'), 'utf8');
+        }
+        await openFileForType(filePath, typeKey);
+    } else if (files.length === 1) {
+        // 只有一个 → 直接打开
+        await openFileForType(files[0], typeKey);
+    } else {
+        // 多个 → 让用户选择
+        const items = files.map(f => ({
+            label: path.relative(novelHelperDir, f),
+            filePath: f,
+        }));
+        const selected = await vscode.window.showQuickPick(items, {
+            placeHolder: `${info.displayName}: 找到 ${files.length} 个配置文件，选择要打开的`,
+            title: '打开配置文件',
+        });
+        if (selected) {
+            await openFileForType(selected.filePath, typeKey);
+        }
+    }
+}
+
+// ── 注册 ─────────────────────────────────────────
+
 export function registerGuidePage(context: vscode.ExtensionContext): void {
     extensionPath = context.extensionPath;
+
+    // 注册 4 个打开配置命令
+    const typeKeys = ['role', 'sensitive', 'vocab', 'regex'];
+    for (const key of typeKeys) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(`andrea.open${key.charAt(0).toUpperCase() + key.slice(1)}Config`, async () => {
+                await openOrCreateConfig(key);
+            })
+        );
+    }
 
     context.subscriptions.push(
         vscode.commands.registerCommand('AndreaNovelHelper.showGuide', async () => {

--- a/src/utils/generateCSpellDictionary.ts
+++ b/src/utils/generateCSpellDictionary.ts
@@ -6,6 +6,18 @@ import { roles } from '../activate';
 import * as crypto from 'crypto';
 import { tokenizeComplexNames } from './utils';
 
+function isLikelyNonNameWord(word: string): boolean {
+    // 长度 > 25 字符的几乎不可能是人名/词条
+    if (word.length > 25) return true;
+    // 包含中文标点符号
+    if (/[：。，！？；、""''（）【】《》…—]/.test(word)) return true;
+    // 包含英文标点（不含连字符和撇号，因为可能是英文名/缩写）
+    if (/[,.;:!?"()]/.test(word)) return true;
+    // 包含空白字符（多词句子碎片）
+    if (/\s/.test(word)) return true;
+    return false;
+}
+
 export function generateCSpellDictionary() {
     if (!roles.length) return;
 
@@ -47,11 +59,14 @@ export function generateCSpellDictionary() {
         }
     }
 
-    // 2. 排序并准备写入内容
-    const sorted = Array.from(wordSet).sort((a, b) => a.localeCompare(b, 'en'));
+    // 2. 格式无关最终过滤：移除明显不是人名/词条的条目（加密防御层）
+    const filtered = Array.from(wordSet).filter(word => !isLikelyNonNameWord(word));
+
+    // 3. 排序并准备写入内容
+    const sorted = filtered.sort((a, b) => a.localeCompare(b, 'en'));
     const newContent = sorted.join('\n');
 
-    // 3. 如果文件已存在且内容一致，则跳过写入
+    // 4. 如果文件已存在且内容一致，则跳过写入
     if (fs.existsSync(dictPath)) {
         const oldContent = fs.readFileSync(dictPath, 'utf8');
         const hashOld = crypto.createHash('sha256').update(oldContent).digest('hex');
@@ -62,11 +77,11 @@ export function generateCSpellDictionary() {
         }
     }
 
-    // 4. 写入文件
+    // 5. 写入文件
     fs.mkdirSync(vscodeDir, { recursive: true });
     fs.writeFileSync(dictPath, newContent, 'utf8');
 
-    // 5. 更新 settings.json 中 cSpell.customDictionaries
+    // 6. 更新 settings.json 中 cSpell.customDictionaries
     const config = vscode.workspace.getConfiguration();
     const current = config.get('cSpell.customDictionaries') as any ?? {};
 

--- a/src/utils/txtRoleDetector.ts
+++ b/src/utils/txtRoleDetector.ts
@@ -2,14 +2,31 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
-/** 文件名角色关键词（第一层过滤） */
-const CHARACTER_FILE_KEYWORDS = [
-    '角色', '人物', 'character', 'role', '主角', '配角',
-    '登场', '设定', '信息', '档案', '介绍',
-];
+/** 从 VS Code 设置读取关键词，带默认值 */
+function getDetectionKeywords(): string[] {
+    const cfg = vscode.workspace.getConfiguration('AndreaNovelHelper');
+    const keywords = cfg.get<string[]>('txtMigration.detectionKeywords');
+    return (keywords && keywords.length) ? keywords : [
+        '角色', '人物', 'character', 'role', '主角', '配角',
+        '登场', '设定', '信息', '档案', '介绍',
+    ];
+}
 
-/** 高置信度目录名称（第二层辅助） */
-const HIGH_CONFIDENCE_DIRS = ['角色', '人物', 'characters', 'roles'];
+function getHighConfidenceDirs(): string[] {
+    const cfg = vscode.workspace.getConfiguration('AndreaNovelHelper');
+    const dirs = cfg.get<string[]>('txtMigration.highConfidenceDirs');
+    return (dirs && dirs.length) ? dirs : ['角色', '人物', 'characters', 'roles'];
+}
+
+function getScoreThreshold(): number {
+    return vscode.workspace.getConfiguration('AndreaNovelHelper')
+        .get<number>('txtMigration.scoreThreshold', 50);
+}
+
+function getHighConfidenceThreshold(): number {
+    return vscode.workspace.getConfiguration('AndreaNovelHelper')
+        .get<number>('txtMigration.highConfidenceScoreThreshold', 30);
+}
 
 export interface TxtRoleFileCandidate {
     filePath: string;
@@ -23,13 +40,13 @@ export interface TxtRoleFileCandidate {
 /** 检查文件名是否包含角色相关关键词 */
 function fileNameHasKeyword(fileName: string): boolean {
     const lower = fileName.toLowerCase();
-    return CHARACTER_FILE_KEYWORDS.some(kw => lower.includes(kw.toLowerCase()));
+    return getDetectionKeywords().some(kw => lower.includes(kw.toLowerCase()));
 }
 
 /** 检查文件是否在高置信度目录下 */
 function isInHighConfidenceDir(filePath: string, workspaceRoot: string): boolean {
     const relative = path.relative(workspaceRoot, path.dirname(filePath)).toLowerCase();
-    return HIGH_CONFIDENCE_DIRS.some(dir => relative.includes(dir.toLowerCase()));
+    return getHighConfidenceDirs().some(dir => relative.includes(dir.toLowerCase()));
 }
 
 /** 对文件内容进行特征评分 */
@@ -162,8 +179,8 @@ export function detectTxtRoleFiles(workspaceRoot: string): TxtRoleFileCandidate[
 
             const { score, rationale } = scoreFileContent(content);
 
-            // 高置信度目录直接收录（门槛降到 30），否则需要 ≥50
-            const threshold = highConf ? 30 : 50;
+            // 高置信度目录使用更低的阈值
+            const threshold = highConf ? getHighConfidenceThreshold() : getScoreThreshold();
             if (score < threshold) continue;
 
             candidates.push({

--- a/src/utils/txtRoleDetector.ts
+++ b/src/utils/txtRoleDetector.ts
@@ -1,0 +1,200 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** 文件名角色关键词（第一层过滤） */
+const CHARACTER_FILE_KEYWORDS = [
+    '角色', '人物', 'character', 'role', '主角', '配角',
+    '登场', '设定', '信息', '档案', '介绍',
+];
+
+/** 高置信度目录名称（第二层辅助） */
+const HIGH_CONFIDENCE_DIRS = ['角色', '人物', 'characters', 'roles'];
+
+export interface TxtRoleFileCandidate {
+    filePath: string;
+    fileName: string;
+    score: number;          // 0-100 内容特征评分
+    lineCount: number;
+    summary: string;        // 简短摘要
+    rationale: string[];    // 判定理由
+}
+
+/** 检查文件名是否包含角色相关关键词 */
+function fileNameHasKeyword(fileName: string): boolean {
+    const lower = fileName.toLowerCase();
+    return CHARACTER_FILE_KEYWORDS.some(kw => lower.includes(kw.toLowerCase()));
+}
+
+/** 检查文件是否在高置信度目录下 */
+function isInHighConfidenceDir(filePath: string, workspaceRoot: string): boolean {
+    const relative = path.relative(workspaceRoot, path.dirname(filePath)).toLowerCase();
+    return HIGH_CONFIDENCE_DIRS.some(dir => relative.includes(dir.toLowerCase()));
+}
+
+/** 对文件内容进行特征评分 */
+function scoreFileContent(content: string): { score: number; rationale: string[] } {
+    const lines = content.split(/\r?\n/).filter(l => l.trim());
+    if (lines.length < 10) {
+        return { score: 0, rationale: ['文件行数过少 (< 10)'] };
+    }
+
+    const totalLines = lines.length;
+    const rationale: string[] = [];
+
+    // 1. 属性行密度：包含中文冒号的行（称号：xxx、年龄：xx 等）
+    const attrLines = lines.filter(l => /[：:]/.test(l) && l.trim().length > 1);
+    const attrDensity = attrLines.length / totalLines;
+    let score = 0;
+
+    if (attrDensity >= 0.20) {
+        score += 30;
+        rationale.push(`属性行密度 ${(attrDensity * 100).toFixed(0)}% (≥20%)`);
+    } else if (attrDensity >= 0.10) {
+        score += 15;
+        rationale.push(`属性行密度 ${(attrDensity * 100).toFixed(0)}% (≥10%)`);
+    }
+
+    // 2. 名称行密度：短行（≤10字）且无中文标点
+    const nameLines = lines.filter(l => {
+        const t = l.trim();
+        return t.length <= 10 && t.length >= 1 && !/[：。，！？；、""''（）【】《》…—]/.test(t);
+    });
+    const nameDensity = nameLines.length / totalLines;
+    if (nameDensity >= 0.15) {
+        score += 25;
+        rationale.push(`名称行密度 ${(nameDensity * 100).toFixed(0)}% (≥15%)`);
+    } else if (nameDensity >= 0.08) {
+        score += 12;
+        rationale.push(`名称行密度 ${(nameDensity * 100).toFixed(0)}% (≥8%)`);
+    }
+
+    // 3. 章节/分类标题（一、二、三… 或 （一）（二）等）
+    const sectionHeaders = lines.filter(l =>
+        /^[一二三四五六七八九十\d]+[、．.)）]/.test(l.trim()) ||
+        /^[（(][一二三四五六七八九十\d]+[）)]/.test(l.trim())
+    );
+    const sectionDensity = sectionHeaders.length / totalLines;
+    if (sectionDensity >= 0.03) {
+        score += 20;
+        rationale.push(`章节标题 ${sectionHeaders.length} 个`);
+    } else if (sectionHeaders.length >= 2) {
+        score += 10;
+        rationale.push(`章节标题 ${sectionHeaders.length} 个`);
+    }
+
+    // 4. 分段结构：空行分隔的段数
+    const blocks = content.split(/\r?\n\r?\n/).filter(b => b.trim());
+    if (blocks.length >= 5) {
+        score += 15;
+        rationale.push(`分段结构 ${blocks.length} 块`);
+    } else if (blocks.length >= 3) {
+        score += 8;
+        rationale.push(`分段结构 ${blocks.length} 块`);
+    }
+
+    // 5. 长段落密度（负面分）：>100 字的行过多则扣分
+    const longLines = lines.filter(l => l.trim().length > 100);
+    const longDensity = longLines.length / totalLines;
+    if (longDensity > 0.30) {
+        score -= 20;
+        rationale.push(`长段落密度 ${(longDensity * 100).toFixed(0)}% (扣除)`);
+    }
+
+    // 确保分数在 0-100 之间
+    score = Math.max(0, Math.min(100, score));
+    rationale.unshift(`总分: ${score}/100`);
+
+    return { score, rationale };
+}
+
+function generateSummary(content: string): string {
+    const lines = content.split(/\r?\n/).filter(l => l.trim());
+    // 找第一个看起来像角色名的行（短、无标点）
+    const nameLine = lines.find(l => {
+        const t = l.trim();
+        return t.length >= 2 && t.length <= 8 &&
+            !/[：。，！？；、""''（）【】《》…—:\s\/\\&]/.test(t) &&
+            !/^[（(【\[]/.test(t) &&
+            !/^[一二三四五六七八九十\d]+[、．.)）]/.test(t);
+    });
+    const firstLine = lines[0]?.trim().substring(0, 60) || '';
+    const candidateName = nameLine?.trim() || '';
+    return candidateName ? `含角色"${candidateName}"等` : firstLine;
+}
+
+/** 扫描工作区，返回候选角色 TXT 文件列表 */
+export function detectTxtRoleFiles(workspaceRoot: string): TxtRoleFileCandidate[] {
+    const candidates: TxtRoleFileCandidate[] = [];
+
+    if (!fs.existsSync(workspaceRoot)) return candidates;
+
+    // 收集所有 .txt 文件（排除 node_modules、.git、.vscode 等）
+    function walkDir(dir: string, depth: number = 0) {
+        if (depth > 6) return;
+        let entries: fs.Dirent[];
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            const baseName = entry.name.toLowerCase();
+
+            // 跳过无关目录
+            if (entry.isDirectory()) {
+                if (['node_modules', '.git', '.vscode', '.anh-fsdb', 'build', 'dist', 'out'].includes(baseName)) continue;
+                walkDir(fullPath, depth + 1);
+                continue;
+            }
+
+            if (!entry.isFile() || !baseName.endsWith('.txt')) continue;
+
+            // 第一层：文件名关键词
+            if (!fileNameHasKeyword(entry.name)) continue;
+
+            // 第二层：目录置信度
+            const highConf = isInHighConfidenceDir(fullPath, workspaceRoot);
+
+            // 第三层：内容评分
+            let content: string;
+            try {
+                content = fs.readFileSync(fullPath, 'utf8');
+            } catch { continue; }
+
+            const { score, rationale } = scoreFileContent(content);
+
+            // 高置信度目录直接收录（门槛降到 30），否则需要 ≥50
+            const threshold = highConf ? 30 : 50;
+            if (score < threshold) continue;
+
+            candidates.push({
+                filePath: fullPath,
+                fileName: path.relative(workspaceRoot, fullPath),
+                score,
+                lineCount: content.split(/\r?\n/).filter(l => l.trim()).length,
+                summary: generateSummary(content),
+                rationale: highConf
+                    ? [`高置信度目录 (阈值: ≥${threshold})`, ...rationale]
+                    : rationale,
+            });
+        }
+    }
+
+    walkDir(workspaceRoot);
+
+    // 按分数降序排列
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates;
+}
+
+/** 扫描所有工作区文件夹 */
+export function detectTxtRoleFilesAll(): TxtRoleFileCandidate[] {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders?.length) return [];
+
+    const all: TxtRoleFileCandidate[] = [];
+    for (const folder of folders) {
+        all.push(...detectTxtRoleFiles(folder.uri.fsPath));
+    }
+    all.sort((a, b) => b.score - a.score);
+    return all;
+}

--- a/src/utils/txtRoleParser.ts
+++ b/src/utils/txtRoleParser.ts
@@ -1,0 +1,323 @@
+import type { Role } from '../extension';
+import * as path from 'path';
+
+/** 属性字段关键词 → 标准字段名映射 */
+const FIELD_KEYWORD_MAP: Record<string, string> = {
+    '称号': 'title',
+    '年龄': 'age',
+    '表面身份': 'surfaceIdentity',
+    '真实身份': 'trueIdentity',
+    '外貌': 'appearance',
+    '性格': 'personality',
+    '核心能力': 'coreAbilities',
+    '其他技能': 'otherSkills',
+    '关系': 'relationships',
+    '动态': 'dynamics',
+    '新增动态': 'dynamics',
+    '身份': 'identity',
+    '背景': 'background',
+    '能力': 'abilities',
+    '技能': 'skills',
+    '描述': 'description',
+    '类型': 'type',
+    '颜色': 'color',
+    '别名': 'aliases',
+    '从属': 'affiliation',
+    '弱点': 'weaknesses',
+    '目标': 'goals',
+    '备注': 'notes',
+    '职业': 'occupation',
+    '性别': 'gender',
+    '出身': 'origin',
+    '栖息地': 'habitat',
+    '本体外观': 'trueFormAppearance',
+    '人类外形': 'humanFormAppearance',
+    '本质': 'essence',
+    '性格与喜好': 'personality',
+    '能力描述': 'abilityDescription',
+    '状态': 'status',
+    '现状': 'status',
+    '目的': 'purpose',
+    '新增': 'dynamics',
+};
+
+function normalizeFieldKey(raw: string): string {
+    const cleaned = raw.replace(/[：:]/g, '').trim();
+    return FIELD_KEYWORD_MAP[cleaned] || cleaned;
+}
+
+function isSectionHeader(line: string): boolean {
+    const t = line.trim();
+    return /^[一二三四五六七八九十\d]+[、．.)）]/.test(t) ||
+        /^[（(][一二三四五六七八九十\d]+[）)]/.test(t) ||
+        /^[#]{1,3}\s/.test(t);
+}
+
+function isMetaLine(line: string): boolean {
+    const t = line.trim();
+    if (!t) return true;
+    if (/^[（(]本档案已更新/.test(t)) return true;
+    if (/^[（(]截至/.test(t)) return true;
+    if (t.startsWith('#') || t.startsWith('//')) return true;
+    return false;
+}
+
+function extractField(line: string): { key: string; value: string } | null {
+    const match = line.match(/^(.+?)[：:]\s*(.*)$/);
+    if (!match) return null;
+    const key = normalizeFieldKey(match[1]);
+    const value = match[2].trim();
+    return { key, value };
+}
+
+function sanitizeName(raw: string): string {
+    return raw
+        .replace(/["""''「」『』]/g, '')   // 去掉各种引号
+        .replace(/[（(][^)）]*[)）]/g, '') // 去掉中文括号注释（新增）（未正式登场）
+        .replace(/\s*[&|]\s*/g, '')       // 去掉连接符 & |
+        .trim();
+    // 注意：/ 保留不处理，因为 "蓝湛 / 镜" 这种需要人工判断是别名还是两个角色
+}
+
+function isLikelyName(line: string): boolean {
+    const t = sanitizeName(line);
+    if (t.length < 1 || t.length > 20) return false;
+    if (/[：。，！？；、""''：:/\s]/.test(t)) return false;
+    if (/^[（(【\[]/.test(t)) return false;
+    if (isSectionHeader(t)) return false;
+    if (extractField(t)) return false;
+    if (/[，。！？；、]/.test(t) && t.length > 10) return false;
+    return true;
+}
+
+export interface ParsedTxtRole {
+    role: Role;
+    rawLines: string[]; // 原始行，供预览用
+}
+
+export interface ParsedTxtSection {
+    sectionTitle: string;
+    roles: ParsedTxtRole[];
+}
+
+export interface ParsedTxtResult {
+    fileName: string;
+    sections: ParsedTxtSection[];
+    totalRoles: number;
+}
+
+/** 解析一个结构化 TXT 角色档案 */
+export function parseTxtRoleFile(content: string, filePath: string): ParsedTxtResult {
+    const lines = content.split(/\r?\n/);
+    const fileName = path.basename(filePath);
+    const sections: ParsedTxtSection[] = [];
+    let currentSection: ParsedTxtSection = { sectionTitle: '默认分组', roles: [] };
+    let currentRole: ParsedTxtRole | null = null;
+    let currentFieldKey = '';
+
+    function flushRole() {
+        if (!currentRole) return;
+        // 将积累的 dynamics/relationships 文本去重并压缩
+        const role = currentRole.role;
+        for (const key of Object.keys(role)) {
+            const val = role[key];
+            if (typeof val === 'string') {
+                role[key] = val.replace(/\n{3,}/g, '\n\n').trim();
+            }
+        }
+        currentSection.roles.push(currentRole);
+        currentRole = null;
+        currentFieldKey = '';
+    }
+
+    function flushSection() {
+        flushRole();
+        if (currentSection.roles.length > 0) {
+            sections.push(currentSection);
+        }
+        currentSection = { sectionTitle: '', roles: [] };
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const line = raw.trim();
+        if (!line) {
+            // 空行：多行字段的段落分隔
+            if (currentRole && currentFieldKey) {
+                currentRole.role[currentFieldKey] = (currentRole.role[currentFieldKey] || '') + '\n';
+            }
+            continue;
+        }
+
+        if (isMetaLine(line)) continue;
+
+        // 章节标题
+        if (isSectionHeader(line)) {
+            flushSection();
+            currentSection = { sectionTitle: line, roles: [] };
+            continue;
+        }
+
+        // 字段行（含冒号）
+        const field = extractField(line);
+        if (field) {
+            // 如果是新角色名级别的字段，先 flush 旧角色
+            if (!currentRole && isLikelyName(field.key)) {
+                // 这可能是："李修缘" 后面跟冒号的情况不常见，先处理为字段
+            }
+            if (!currentRole) {
+                // 没有当前角色时，字段可能是角色的第一个属性
+                // 需要判断：前面一行是否是角色名
+                continue;
+            }
+
+            currentFieldKey = field.key;
+            const existing = currentRole.role[currentFieldKey];
+            if (existing && typeof existing === 'string') {
+                currentRole.role[currentFieldKey] = existing + '\n' + field.value;
+            } else {
+                currentRole.role[currentFieldKey] = field.value;
+            }
+            continue;
+        }
+
+        // 非空行、非章节标题、非字段行 → 可能是角色名或继续上文字段内容
+        if (currentRole && currentFieldKey) {
+            // 强名称信号（sanitizeName 处理引号/括号/连接符后判定）
+            if (isLikelyName(line)) {
+                flushRole();
+                currentRole = {
+                    role: {
+                        name: sanitizeName(line),
+                        type: '角色',
+                        sourcePath: filePath,
+                        packagePath: '',
+                    },
+                    rawLines: [raw],
+                };
+                currentFieldKey = '';
+            } else {
+                // 继续追加到当前字段
+                currentRole.role[currentFieldKey] = (currentRole.role[currentFieldKey] || '') + '\n' + line;
+            }
+        } else if (isLikelyName(line)) {
+            // 新角色名
+            flushRole();
+            currentRole = {
+                role: {
+                    name: sanitizeName(line),
+                    type: '角色',
+                    sourcePath: filePath,
+                    packagePath: '',
+                },
+                rawLines: [raw],
+            };
+            currentFieldKey = '';
+        } else if (currentRole) {
+            // 没有当前字段时的描述文本 → 存为描述
+            currentRole.role.description = (currentRole.role.description || '') + '\n' + line;
+        }
+    }
+
+    flushSection();
+
+    return {
+        fileName,
+        sections,
+        totalRoles: sections.reduce((sum, s) => sum + s.roles.length, 0),
+    };
+}
+
+/** 将 ParsedTxtResult 转换为 JSON5 字符串 */
+export function toJson5(result: ParsedTxtResult): string {
+    const allRoles: Role[] = [];
+    for (const section of result.sections) {
+        for (const pr of section.roles) {
+            allRoles.push(pr.role);
+        }
+    }
+    return serializeRolesToJson5(allRoles);
+}
+
+/** 将 ParsedTxtResult 转换为 Markdown 角色档案 */
+export function toMarkdown(result: ParsedTxtResult): string {
+    const parts: string[] = [];
+    parts.push(`# ${result.fileName.replace(/\.txt$/i, '')}\n`);
+
+    for (const section of result.sections) {
+        if (section.sectionTitle && section.sectionTitle !== '默认分组') {
+            parts.push(`## ${section.sectionTitle}\n`);
+        }
+        for (const pr of section.roles) {
+            const r = pr.role;
+            parts.push(`### ${r.name}`);
+            parts.push('');
+
+            const order = ['type', 'title', 'age', 'gender', 'occupation', 'affiliation',
+                'surfaceIdentity', 'trueIdentity', 'identity', 'appearance', 'personality',
+                'coreAbilities', 'otherSkills', 'abilities', 'skills', 'weaknesses',
+                'relationships', 'dynamics', 'background', 'origin', 'habitat',
+                'trueFormAppearance', 'humanFormAppearance', 'essence',
+                'purpose', 'status', 'notes'];
+
+            const written = new Set<string>(['name']);
+            for (const key of order) {
+                const val = (r as any)[key];
+                if (val !== undefined && val !== '') {
+                    parts.push(`#### ${key}`);
+                    parts.push(String(val).trim());
+                    parts.push('');
+                    written.add(key);
+                }
+            }
+            // 其他未分类字段
+            for (const key of Object.keys(r)) {
+                if (written.has(key) || key === 'sourcePath' || key === 'packagePath') continue;
+                const val = (r as any)[key];
+                if (val !== undefined && val !== '' && typeof val === 'string') {
+                    parts.push(`#### ${key}`);
+                    parts.push(val.trim());
+                    parts.push('');
+                }
+            }
+        }
+    }
+    return parts.join('\n');
+}
+
+function serializeRolesToJson5(roles: Role[]): string {
+    const lines: string[] = ['['];
+    for (let i = 0; i < roles.length; i++) {
+        const r = roles[i];
+        const obj: any = { name: r.name, type: r.type || '角色' };
+        if (r.description) obj.description = r.description;
+        if (r.aliases?.length) obj.aliases = r.aliases;
+        if (r.color) obj.color = r.color;
+        if (r.affiliation) obj.affiliation = r.affiliation;
+
+        for (const key of Object.keys(r)) {
+            if (['name', 'type', 'description', 'aliases', 'color', 'affiliation',
+                'sourcePath', 'packagePath', 'uuid'].includes(key)) continue;
+            const val = (r as any)[key];
+            if (val !== undefined && val !== '' && typeof val === 'string') {
+                obj[key] = val;
+            }
+        }
+
+        const entries = Object.entries(obj);
+        const inner = entries.map(([k, v]) => {
+            const escaped = String(v)
+                .replace(/\\/g, '\\\\')
+                .replace(/"/g, '\\"')
+                .replace(/\n/g, '\\n')
+                .replace(/\r/g, '\\r')
+                .replace(/\t/g, '\\t');
+            return `    "${k}": "${escaped}"`;
+        }).join(',\n');
+
+        const comma = i < roles.length - 1 ? ',' : '';
+        lines.push(`  {\n${inner}\n  }${comma}`);
+    }
+    lines.push(']');
+    return lines.join('\n') + '\n';
+}

--- a/src/utils/txtRoleParser.ts
+++ b/src/utils/txtRoleParser.ts
@@ -1,5 +1,6 @@
 import type { Role } from '../extension';
 import * as path from 'path';
+import JSON5 from 'json5';
 
 /** 属性字段关键词 → 标准字段名映射 */
 const FIELD_KEYWORD_MAP: Record<string, string> = {
@@ -286,9 +287,7 @@ export function toMarkdown(result: ParsedTxtResult): string {
 }
 
 function serializeRolesToJson5(roles: Role[]): string {
-    const lines: string[] = ['['];
-    for (let i = 0; i < roles.length; i++) {
-        const r = roles[i];
+    const cleaned = roles.map(r => {
         const obj: any = { name: r.name, type: r.type || '角色' };
         if (r.description) obj.description = r.description;
         if (r.aliases?.length) obj.aliases = r.aliases;
@@ -303,21 +302,8 @@ function serializeRolesToJson5(roles: Role[]): string {
                 obj[key] = val;
             }
         }
+        return obj;
+    });
 
-        const entries = Object.entries(obj);
-        const inner = entries.map(([k, v]) => {
-            const escaped = String(v)
-                .replace(/\\/g, '\\\\')
-                .replace(/"/g, '\\"')
-                .replace(/\n/g, '\\n')
-                .replace(/\r/g, '\\r')
-                .replace(/\t/g, '\\t');
-            return `    "${k}": "${escaped}"`;
-        }).join(',\n');
-
-        const comma = i < roles.length - 1 ? ',' : '';
-        lines.push(`  {\n${inner}\n  }${comma}`);
-    }
-    lines.push(']');
-    return lines.join('\n') + '\n';
+    return JSON5.stringify(cleaned, { space: 2, quote: '"' }) + '\n';
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1229,6 +1229,22 @@ function loadDelimitedRoleFile(content: string, filePath: string, packagePath: s
 	}
 }
 
+function isLikelyNonNameLine(line: string): boolean {
+	// 长度 > 50 字大概率是叙事文本，不是人名/词条
+	if (line.length > 50) return true;
+	// 以括号/方括号开头：元信息、章节标记
+	if (/^[（(【[]/.test(line)) return true;
+	// 包含冒号：属性字段 或 标题式冒号结尾
+	if (/[：:]/.test(line) && line.length > 2) return true;
+	// 编号标题：一、 二、 1. 1、 （一） 等
+	if (/^[一二三四五六七八九十0-9]+[、．.)）]/.test(line)) return true;
+	// 含句子标点的长叙述句
+	if (/[，。！？；、]/.test(line) && line.length > 15) return true;
+	// 含有中文括号注释（如 xxx（新增）、"力"（未正式登场））
+	if (/[（(]/.test(line) && /[）)]/.test(line)) return true;
+	return false;
+}
+
 function loadTXTRoleFile(content: string, filePath: string, packagePath: string, defaultType: string) {
 	const cfg = vscode.workspace.getConfiguration('AndreaNovelHelper');
 	const rawLines = content.split(/\r?\n/);
@@ -1249,6 +1265,9 @@ function loadTXTRoleFile(content: string, filePath: string, packagePath: string,
 			line = line.slice(0, cutIdx).trim();
 			if (!line) continue;
 		}
+			// 启发式过滤：跳过明显不是人名/词条的行（长句、元信息、属性字段、章节标题）
+			if (isLikelyNonNameLine(line)) continue;
+
 		const role: Role = {
 			name: line,
 			type: defaultType,


### PR DESCRIPTION
# Feature: "Open Config" Quick Buttons in Guide Page

## Summary

Added an "Open Config" button to each of the four feature cards in the "Roles & Resources" section of the ANH Guide page. One click detects and opens the corresponding configuration file in the project.

## Problem

Previously, the guide cards only had a "View Docs" button. After reading the docs, users had to manually navigate to the `novel-helper/` directory and find the right config file. New users often didn't know where the files were or what they should be named.

## Solution

Each feature card now has an "打开配置" (Open Config) button:

| Files found | Behavior |
|-------------|----------|
| 0 | Prompt to choose format (JSON5 / MD) → auto-create template with default filename → open |
| 1 | Open directly |
| 2+ | QuickPick list for user to choose |

### Four Commands

| Card | Command ID | Default File | Search Keywords |
|------|-----------|-------------|-----------------|
| 角色管理 (Roles) | `andrea.openRoleConfig` | `character-gallery.*` | `character-gallery`, `character`, `role`, `roles` |
| 敏感词检测 (Sensitive Words) | `andrea.openSensitiveConfig` | `sensitive-words.*` | `sensitive-words`, `sensitive`, `敏感词` |
| 词汇表 (Vocabulary) | `andrea.openVocabConfig` | `vocabulary.*` | `vocabulary`, `vocab`, `词汇`, `术语` |
| 正则着色 (Regex Coloring) | `andrea.openRegexConfig` | `regex-patterns.*` | `regex-patterns`, `regex`, `正则` |

### File Opening

All types use the default text editor (`vscode.openWith ... default`) to avoid the Role JSON5 custom editor incorrectly rendering sensitive-word, vocabulary, and regex-pattern `.json5` files as character forms.

## UI

```
┌─────────────────────────────────────────┐
│  🧑  Role Management                     │
│  Manage characters via role card editor.  │
│  [View Docs] [Open Config]                │
└─────────────────────────────────────────┘
```

## Files Changed

| File | Change |
|------|--------|
| `src/guide/guidePage.ts` | Added `CONFIG_TYPES` mapping, `findConfigFiles()` scanner, `openOrCreateConfig()` open/create logic, `openFileForType()` helper, 4 command registrations |
| `media/guide.html` | Added "打开配置" button next to "查看文档" in each of the 4 cards (via `data-cmd` attributes) |

### Reuses Existing Infrastructure

- File scanning: lightweight keyword + extension matching
- Template creation: simplified inline templates matching `templateGenerators.ts` style
- Button clicks: reused `guide.js` existing `[data-cmd]` event delegation

## Compatibility

- Non-breaking: only adds UI buttons and commands
- Buttons are in the Guide page WebView only (not sidebar or context menus)
- Guides user to create a file when none exists; never errors out
